### PR TITLE
Document CDN WAF rate-limit config (ops/)

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -1,0 +1,40 @@
+# Ops
+
+Infrastructure config for the dataset's S3 bucket + CloudFront distribution
+(`s3://fpv-drone-strikes-lebanon-dataset` → `d2fioemadmrru3.cloudfront.net`,
+distribution `E1FTYLW4OET6KU`).
+
+## WAF rate limiting (`waf-rules.json`)
+
+The distribution is protected by the WAFv2 WebACL `fpv-dataset-ratelimit`
+(scope `CLOUDFRONT`, region `us-east-1`, id `29b603ed-8495-4c3e-a74f-5601cbba7e4c`),
+default action **Allow**, with two per-IP rate rules:
+
+| Rule | Scope | Limit (per IP / 5 min) | Purpose |
+| --- | --- | --- | --- |
+| `RateLimitVideos` | path starts with `/videos/` | 300 | throttle bulk MP4 scraping / hotlinking |
+| `RateLimitStatic` | all requests | 3000 | generous ceiling for the web viewer (thumbnails, scenes, frames, `data/videos.json`); still stops asset-library scrapers |
+
+The video request counts toward both, so the 300 cap on `/videos/` always holds.
+`RateLimitStatic` was sized for the viewer: a gallery load (~150 thumbnails) plus
+several 3D scenes (~30 requests each, since the scene view windows its frame
+preloading) stays well under 3000.
+
+`waf-rules.json` uses base64 for the byte-match string (`L3ZpZGVvcy8=` = `/videos/`),
+as the AWS CLI expects for that blob field.
+
+### Apply
+
+```bash
+export AWS_PROFILE=admin   # or a profile with wafv2 write access
+LOCK=$(aws wafv2 get-web-acl --scope CLOUDFRONT --region us-east-1 \
+  --name fpv-dataset-ratelimit --id 29b603ed-8495-4c3e-a74f-5601cbba7e4c \
+  --query LockToken --output text)
+aws wafv2 update-web-acl --scope CLOUDFRONT --region us-east-1 \
+  --name fpv-dataset-ratelimit --id 29b603ed-8495-4c3e-a74f-5601cbba7e4c \
+  --lock-token "$LOCK" --default-action Allow={} \
+  --visibility-config SampledRequestsEnabled=true,CloudWatchMetricsEnabled=true,MetricName=fpv-dataset-ratelimit \
+  --rules file://ops/waf-rules.json
+```
+
+Tune limits by editing `waf-rules.json` and re-applying.

--- a/ops/waf-rules.json
+++ b/ops/waf-rules.json
@@ -1,0 +1,44 @@
+[
+  {
+    "Name": "RateLimitVideos",
+    "Priority": 0,
+    "Statement": {
+      "RateBasedStatement": {
+        "Limit": 300,
+        "EvaluationWindowSec": 300,
+        "AggregateKeyType": "IP",
+        "ScopeDownStatement": {
+          "ByteMatchStatement": {
+            "SearchString": "L3ZpZGVvcy8=",
+            "FieldToMatch": { "UriPath": {} },
+            "TextTransformations": [{ "Priority": 0, "Type": "NONE" }],
+            "PositionalConstraint": "STARTS_WITH"
+          }
+        }
+      }
+    },
+    "Action": { "Block": {} },
+    "VisibilityConfig": {
+      "SampledRequestsEnabled": true,
+      "CloudWatchMetricsEnabled": true,
+      "MetricName": "RateLimitVideos"
+    }
+  },
+  {
+    "Name": "RateLimitStatic",
+    "Priority": 1,
+    "Statement": {
+      "RateBasedStatement": {
+        "Limit": 3000,
+        "EvaluationWindowSec": 300,
+        "AggregateKeyType": "IP"
+      }
+    },
+    "Action": { "Block": {} },
+    "VisibilityConfig": {
+      "SampledRequestsEnabled": true,
+      "CloudWatchMetricsEnabled": true,
+      "MetricName": "RateLimitStatic"
+    }
+  }
+]


### PR DESCRIPTION
Records the WAFv2 rate-limit rules on the dataset CloudFront distribution as infra-as-code (they were console-only), with the apply command.

- `RateLimitVideos` — 300/5min per IP, scoped to `/videos/*` (bulk MP4 scraping)
- `RateLimitStatic` — 3000/5min per IP, all paths (generous ceiling for the web viewer)

Already applied to the live WebACL `fpv-dataset-ratelimit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)