### PR TITLE
Bake measured scale into scene metadata; base scenes only in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "FPV drone strike dataset: video references, annotations, and the annotation/scene tooling. npm scripts here publish the web data consumed by itamarweiss.com/fpv.",
   "scripts": {
     "gen-thumbnails": "node tools/gen_thumbnails.mjs",
+    "apply-calibration": "node tools/apply_calibration.mjs",
     "build-web-data": "node tools/build_web_data.mjs",
     "publish-web": "tools/publish_web.sh",
     "publish-web:fast": "tools/publish_web.sh --skip-scenes"

--- a/tools/apply_calibration.mjs
+++ b/tools/apply_calibration.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/**
+ * Bake measured scale into scene metadata.
+ *
+ * The measure tool writes a calibrated scale to a scene's scene_state.json
+ * (reason "measured_scale"), but the read-only web viewer only reads
+ * scene_meta.json. This copies a real measurement into every scene_meta.json of
+ * the same video so the viewer reports absolute height/speed instead of the
+ * generic 117.6 m/unit fallback. Idempotent; run before publishing.
+ *
+ *   node tools/apply_calibration.mjs
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const scenesDir = path.join(repoRoot, "scenes");
+
+function readJson(p) {
+  try {
+    return JSON.parse(fs.readFileSync(p, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+// A scene_state.json only counts as a real calibration if it came from a
+// measurement (two picked points on a known length), not a default/verify pass.
+function measuredScale(sceneDir) {
+  const st = readJson(path.join(sceneDir, "scene_state.json"));
+  if (!st) return null;
+  if (st.reason !== "measured_scale" || !st.measured_vggt_units) return null;
+  const s = Number(st.scale_m_per_unit);
+  if (!(s > 0)) return null;
+  return {
+    scale: s,
+    real_length_m: st.real_length_m ?? null,
+    measured_vggt_units: st.measured_vggt_units,
+    updated_at: st.updated_at ?? null,
+  };
+}
+
+let applied = 0;
+if (fs.existsSync(scenesDir)) {
+  for (const stem of fs.readdirSync(scenesDir, { withFileTypes: true })) {
+    if (!stem.isDirectory()) continue;
+    const stemDir = path.join(scenesDir, stem.name);
+    const sceneDirs = fs
+      .readdirSync(stemDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => path.join(stemDir, d.name));
+
+    // The measurement is a property of the reconstruction, so any scene dir of
+    // this video (base or variant) that has one applies to all of them.
+    let cal = null;
+    for (const d of sceneDirs) {
+      cal = measuredScale(d);
+      if (cal) break;
+    }
+    if (!cal) continue;
+
+    for (const d of sceneDirs) {
+      const metaPath = path.join(d, "viewer", "scene_meta.json");
+      const meta = readJson(metaPath);
+      if (!meta) continue;
+      meta.default_scale_m_per_unit = cal.scale;
+      meta.calibration = {
+        scale_m_per_vggt_unit: cal.scale,
+        real_length_m: cal.real_length_m,
+        measured_vggt_units: cal.measured_vggt_units,
+        source: "measured",
+        measured_at: cal.updated_at,
+      };
+      fs.writeFileSync(metaPath, JSON.stringify(meta));
+      applied += 1;
+    }
+    console.log(`calibrated ${stem.name}: ${cal.scale.toFixed(2)} m/unit (${cal.real_length_m ?? "?"} m ref)`);
+  }
+}
+console.log(`done: baked calibration into ${applied} scene_meta.json file(s)`);

--- a/tools/build_web_data.mjs
+++ b/tools/build_web_data.mjs
@@ -57,7 +57,9 @@ function readAnnotations() {
   return byVideo;
 }
 
-// Map each video slug -> ALL completed scene variants (sorted, canonical first).
+// Map each video slug -> its published scene path. Production ships the base
+// reconstruction only; density variants (scene dirs suffixed "__3m"/"__5m"/...)
+// exist for the local scene-viewer tool and are excluded here.
 function buildSceneIndex() {
   const scenesDir = path.join(repoRoot, "scenes");
   const index = new Map();
@@ -65,16 +67,15 @@ function buildSceneIndex() {
   for (const stem of fs.readdirSync(scenesDir, { withFileTypes: true })) {
     if (!stem.isDirectory()) continue;
     const base = path.join(scenesDir, stem.name);
-    const variants = [];
     for (const scene of fs.readdirSync(base, { withFileTypes: true }).sort((a, b) =>
       a.name.localeCompare(b.name),
     )) {
-      if (!scene.isDirectory()) continue;
+      if (!scene.isDirectory() || scene.name.includes("__")) continue; // skip variants
       if (fs.existsSync(path.join(base, scene.name, "viewer", "scene_meta.json"))) {
-        variants.push(`${stem.name}/${scene.name}`);
+        index.set(stem.name, `${stem.name}/${scene.name}`);
+        break;
       }
     }
-    if (variants.length) index.set(stem.name, variants);
   }
   return index;
 }
@@ -103,7 +104,7 @@ for (const raw of readAnnotatorVideos()) {
   const slug = slugify(videoFile);
   const ann = annotations.get(videoFile);
   const thumb = thumbs[slug];
-  const scenePaths = sceneIndex.get(slug) ?? null;
+  const scenePath = sceneIndex.get(slug) ?? null;
   videos.push({
     videoFile,
     slug,
@@ -114,8 +115,7 @@ for (const raw of readAnnotatorVideos()) {
     thumbnailUrl: (raw.thumbnail_url ?? "").trim(),
     thumbWidths: thumb?.widths ?? null,
     blur: thumb?.blurDataURL ?? null,
-    scenePath: scenePaths?.[0] ?? null,
-    scenePaths,
+    scenePath,
     segments: ann?.segments ?? null,
     annotationAuto: ann ? Boolean(ann.auto_generated) : null,
   });

--- a/tools/publish_web.sh
+++ b/tools/publish_web.sh
@@ -23,7 +23,8 @@ cd "$REPO"
 echo "== 1/5 generate thumbnails (incremental) =="
 node tools/gen_thumbnails.mjs
 
-echo "== 2/5 build web data manifest =="
+echo "== 2/5 bake calibration + build web data manifest =="
+node tools/apply_calibration.mjs
 node tools/build_web_data.mjs
 
 echo "== 3/5 upload thumbnails =="
@@ -33,16 +34,19 @@ aws s3 sync build/thumbnails/ "$BUCKET/thumbnails/" \
   --cache-control "public,max-age=31536000,immutable"
 
 if [ "$SKIP_SCENES" = "0" ]; then
-  echo "== 4/5 upload scene viewer data =="
+  echo "== 4/5 upload scene viewer data (incremental, base only) =="
   for d in scenes/*/*/viewer; do
     [ -f "$d/scene_meta.json" ] || continue
-    aws s3 cp "$d/scene_meta.json" "$BUCKET/$d/" \
+    # Production ships base reconstructions only; skip density variants.
+    case "$d" in *__*) continue;; esac
+    # sync skips unchanged files (size+mtime), so re-publishing is cheap
+    aws s3 sync "$d/" "$BUCKET/$d/" \
+      --exclude "*" --include "scene_meta.json" \
       --content-type application/json --cache-control "public,max-age=300"
-    for bin in points_positions.bin points_colors.bin; do
-      [ -f "$d/$bin" ] && aws s3 cp "$d/$bin" "$BUCKET/$d/" \
-        --content-type application/octet-stream \
-        --cache-control "public,max-age=31536000"
-    done
+    aws s3 sync "$d/" "$BUCKET/$d/" \
+      --exclude "*" --include "*.bin" \
+      --content-type application/octet-stream \
+      --cache-control "public,max-age=31536000"
     [ -d "$d/camera_view_assets" ] && aws s3 sync "$d/camera_view_assets/" \
       "$BUCKET/$d/camera_view_assets/" \
       --content-type image/jpeg --cache-control "public,max-age=31536000,immutable"


### PR DESCRIPTION
Fixes calibrated scenes rendering at the 117.6 m/unit fallback (so height/speed were wrong) and drops density variants from production.

- **apply_calibration.mjs** bakes measurements from scene_state.json into scene_meta.json (calibration + default_scale). Runs in publish. 4 videos measured: barashit, namer_apc_khiam, d9_beaufort_17598, bayyadah_17434.
- **base-only**: the manifest + publish exclude __3m/__5m variants; they stay local for the scene-viewer tool.

No viewer code change needed — it already reads calibration from meta. Requires re-publish (done separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)