### PR TITLE
Document catalog source-of-truth migration

### DIFF
--- a/docs/catalog_source_of_truth_plan.md
+++ b/docs/catalog_source_of_truth_plan.md
@@ -1,0 +1,151 @@
+# Catalog source-of-truth implementation plan
+
+## End state
+
+The FPV repository owns all durable dataset state:
+
+- `data/catalog.json` identifies every video and its descriptive metadata.
+- `annotations/<video-id>_annotations.json` owns annotation content.
+- `scene-manifests/<video-id>/<scene-id>.json` records lightweight scene metadata.
+- `data/redirects.json` records old-to-current identities and review dates.
+
+S3/CloudFront contains media and generated runtime artifacts. `README.md`, the
+annotator video list, and `data/videos.json` are generated projections. The
+`itamarweiss.com/fpv` application only consumes `data/videos.json`; it does not
+own a second catalog.
+
+## Catalog record
+
+```json
+{
+  "id": "2026-05-26_anti_drone_platform_biranit",
+  "date": "2026-05-26",
+  "description": "Iron Dome platform, Biranit barracks...",
+  "original_title": "...",
+  "town": "Biranit barracks (Israel), approx",
+  "provenance": {
+    "source": "telegram",
+    "source_url": "https://t.me/...",
+    "discovered_at": "2026-07-12T00:00:00Z"
+  },
+  "media": {
+    "video_key": "videos/2026-05-26_anti_drone_platform_biranit.mp4",
+    "thumbnail_key": "thumbnails/2026-05-26_anti_drone_platform_biranit.jpg"
+  }
+}
+```
+
+The stable `id` is the filename stem. Optional annotations and scenes are joined
+by this ID rather than copied into the catalog. A missing annotation or scene is
+a valid lifecycle state, not a validation failure. Derived status values are:
+`media_published`, `annotated`, and `scene_published`.
+
+## Redirect record
+
+```json
+{
+  "from": "2026-05-26_anti_drone_platform_barashit",
+  "to": "2026-05-26_anti_drone_platform_biranit",
+  "created_at": "2026-07-12",
+  "review_after": "2026-10-15",
+  "reason": "Correct place-name spelling"
+}
+```
+
+One redirect record generates both CloudFront asset redirects and website route
+redirects. Systematic migrations, such as underscore dates, remain compact
+rules. Semantic renames use explicit records.
+
+## Commands
+
+The final operator interface should be:
+
+```bash
+npm run dataset:add -- --video /path/video.mp4 --thumbnail /path/thumb.jpg --metadata /path/record.json
+npm run dataset:annotate -- --id <video-id> --annotation /path/annotation.json
+npm run dataset:add-scene -- --id <video-id> --scene /path/scene
+npm run dataset:rename -- --from <old-id> --to <new-id> --reason "..."
+npm run dataset:publish
+npm run dataset:verify
+```
+
+Each mutation validates locally and changes Git-owned files. Publishing is a
+separate, idempotent step.
+
+## Transaction order
+
+Every publish follows the same order:
+
+1. Validate schema, unique IDs, names, references, and redirect chains.
+2. Generate README and the annotator/web projections in a temporary directory.
+3. Upload new video, thumbnail, annotation, and scene objects.
+4. Verify every newly referenced CloudFront URL returns success.
+5. Deploy redirect data/rules.
+6. Publish `data/videos.json` last, using an atomic S3 object replacement.
+7. Run the complete public integrity check.
+
+If any step before 6 fails, the public manifest remains unchanged. Old objects
+are removed only after redirects and the new manifest have been verified.
+
+## Implementation phases
+
+### 1. Introduce the catalog without changing production
+
+- Add JSON Schemas for `catalog.json`, redirects, and scene manifests.
+- Import the current 149 README-backed records.
+- Add a validator that compares catalog, README, annotator, annotations, and S3
+  while allowing catalog records that do not yet have annotations or scenes.
+- Require generated output to match the existing checked-in output exactly.
+
+Acceptance: catalog validation passes and the generated manifest has no semantic
+diff from production.
+
+### 2. Generate duplicated views
+
+- Generate the README video table from the catalog.
+- Generate annotator input JSON from the catalog; remove embedded `const VIDEOS`.
+- Make `build_web_data.mjs` consume catalog + annotations + scene manifests.
+- Add `git diff --exit-code` checks for generated files in CI.
+
+Acceptance: editing the catalog is the only way to add or rename a video.
+
+### 3. Add transactional publishing
+
+- Implement the six `dataset:*` commands above.
+- Publish changed assets first and `videos.json` last.
+- Preserve scene references when publishing from a clean checkout.
+- Record a release report containing uploaded keys and verification results.
+
+Acceptance: a failed upload cannot expose a broken card on the website.
+
+### 4. Automate after merge
+
+- Run validation on pull requests.
+- Publish on merge to `main` through GitHub Actions and AWS OIDC.
+- Keep credentials out of GitHub secrets where OIDC roles can be used.
+- Prevent concurrent publishers with one workflow concurrency group.
+
+Acceptance: merging a valid dataset PR updates CloudFront and the website without
+a separate website commit or manual deployment.
+
+### 5. Switch OpenClaw to the catalog contract
+
+- OpenClaw uploads media, then opens a PR containing one catalog record.
+- It never edits README or the website repository directly.
+- It records Telegram provenance and an idempotency key/message ID.
+- Reprocessing the same Telegram post must update or skip the existing record,
+  never create a duplicate.
+
+Acceptance: OpenClaw can ingest the same message twice without duplicate media,
+catalog rows, or README entries.
+
+## Pull-request split
+
+1. Catalog schema, importer, validator, and generated-output comparison.
+2. README/annotator/manifest generators switched to catalog input.
+3. Transactional publisher, redirects generator, and integrity report.
+4. GitHub Actions OIDC publishing.
+5. OpenClaw integration against the stable command contract.
+
+This keeps each behavioral change reviewable and preserves the current working
+pipeline throughout the migration.

--- a/docs/openclaw_ingest_handoff.md
+++ b/docs/openclaw_ingest_handoff.md
@@ -1,0 +1,92 @@
+# OpenClaw FPV ingest handoff
+
+Repository: `itamarwe/fpv-drone-strikes-lebanon-dataset`
+
+Public asset base: `https://d2fioemadmrru3.cloudfront.net`
+
+Never commit credentials, local environment files, downloaded media, or AWS
+configuration. Never make the S3 bucket public.
+
+## Current workflow
+
+Until `data/catalog.json` and the `dataset:*` commands land:
+
+1. Derive one canonical stem: `YYYY-MM-DD_short_description`, lowercase with
+   underscores.
+2. Check README, the annotator list, and S3 for the stem and Telegram message ID
+   before uploading. Stop on a likely duplicate.
+3. Upload the MP4 to `videos/<stem>.mp4` and JPG to
+   `thumbnails/<stem>.jpg` in the private dataset bucket.
+4. Verify both CloudFront URLs return HTTP 200.
+5. Add the video to both `README.md` and `tools/annotator.html`, using identical
+   date, description, town, thumbnail URL, and video URL.
+6. Open a pull request. Do not edit the `itamarwe.github.io` repository: the
+   website reads the CloudFront manifest.
+7. Run `npm run publish-web:fast` after the repository change is accepted so
+   responsive thumbnails and `data/videos.json` are updated.
+8. Run `npm run check-public` after publishing and confirm the new card, video,
+   and thumbnail resolve. The current `npm run audit` requires an annotation, so
+   run it after the annotation stage until the catalog-aware validator replaces
+   it.
+
+Upload assets before publishing references. Publish `data/videos.json` last.
+
+## Target workflow
+
+After the catalog migration, replace steps 3-8 with:
+
+```bash
+npm run dataset:add -- \
+  --video /path/to/video.mp4 \
+  --thumbnail /path/to/thumbnail.jpg \
+  --metadata /path/to/catalog-record.json
+```
+
+Then open a PR containing the catalog change. OpenClaw must not edit generated
+README rows, annotator lists, redirects, or the website repository directly.
+The post-merge publisher will generate and publish those views.
+
+## Required metadata
+
+Provide:
+
+- canonical `id`/stem and date
+- concise English description
+- original Arabic title when available
+- town/location, with `approx` when uncertain
+- Telegram source URL, channel, message ID, and discovery timestamp
+- source video and thumbnail paths
+
+The Telegram channel + message ID is the ingestion idempotency key.
+
+## Annotation and scene stages
+
+OpenClaw only performs discovery and initial media ingestion. Later tools attach
+data using the same video ID:
+
+```bash
+npm run dataset:annotate -- --id <video-id> --annotation <file>
+npm run dataset:add-scene -- --id <video-id> --scene <directory>
+```
+
+Neither stage creates a second catalog entry.
+
+## Renames
+
+Never rename S3 keys or Git files ad hoc. Use:
+
+```bash
+npm run dataset:rename -- --from <old-id> --to <new-id> --reason "..."
+```
+
+This must copy assets, update catalog/annotation/scene references, add redirect
+records, publish the new manifest, verify old and new URLs, and only then remove
+old objects.
+
+## Failure behavior
+
+- If upload succeeds but Git/validation fails, leave the object unreferenced and
+  report its key; do not publish a partial manifest.
+- If CloudFront verification fails, do not add or merge the catalog record.
+- If metadata is uncertain, mark it for review instead of guessing a filename.
+- If a possible duplicate exists, stop and report both records.


### PR DESCRIPTION
## Summary
- define the concrete catalog, redirect, scene-manifest, publishing, and CI ownership model
- split implementation into five reviewable phases with acceptance criteria
- add a credential-free OpenClaw handoff covering the current safe workflow and target dataset command contract
- make unannotated and scene-less videos valid lifecycle states

Documentation only; no runtime behavior changes.