### PR TITLE
Make ingest documentation implementation-neutral

### DIFF
--- a/docs/catalog_source_of_truth_plan.md
+++ b/docs/catalog_source_of_truth_plan.md
@@ -128,15 +128,15 @@ Acceptance: a failed upload cannot expose a broken card on the website.
 Acceptance: merging a valid dataset PR updates CloudFront and the website without
 a separate website commit or manual deployment.
 
-### 5. Switch OpenClaw to the catalog contract
+### 5. Switch ingest producers to the catalog contract
 
-- OpenClaw uploads media, then opens a PR containing one catalog record.
+- The Telegram crawler uploads media, then opens a PR containing one catalog record.
 - It never edits README or the website repository directly.
 - It records Telegram provenance and an idempotency key/message ID.
 - Reprocessing the same Telegram post must update or skip the existing record,
   never create a duplicate.
 
-Acceptance: OpenClaw can ingest the same message twice without duplicate media,
+Acceptance: the crawler can ingest the same message twice without duplicate media,
 catalog rows, or README entries.
 
 ## Pull-request split
@@ -145,7 +145,7 @@ catalog rows, or README entries.
 2. README/annotator/manifest generators switched to catalog input.
 3. Transactional publisher, redirects generator, and integrity report.
 4. GitHub Actions OIDC publishing.
-5. OpenClaw integration against the stable command contract.
+5. Crawler integration against the stable ingest command contract.
 
 This keeps each behavioral change reviewable and preserves the current working
 pipeline throughout the migration.

--- a/docs/ingest_instructions.md
+++ b/docs/ingest_instructions.md
@@ -1,4 +1,4 @@
-# OpenClaw FPV ingest handoff
+# FPV ingest instructions
 
 Repository: `itamarwe/fpv-drone-strikes-lebanon-dataset`
 
@@ -42,7 +42,7 @@ npm run dataset:add -- \
   --metadata /path/to/catalog-record.json
 ```
 
-Then open a PR containing the catalog change. OpenClaw must not edit generated
+Then open a PR containing the catalog change. Ingest producers must not edit generated
 README rows, annotator lists, redirects, or the website repository directly.
 The post-merge publisher will generate and publish those views.
 
@@ -61,7 +61,7 @@ The Telegram channel + message ID is the ingestion idempotency key.
 
 ## Annotation and scene stages
 
-OpenClaw only performs discovery and initial media ingestion. Later tools attach
+The ingest producer only performs discovery and initial media ingestion. Later tools attach
 data using the same video ID:
 
 ```bash


### PR DESCRIPTION
Rename the crawler-specific handoff to docs/ingest_instructions.md and describe a generic ingest producer contract. Telegram crawling remains one implementation, not part of the durable architecture.