### PR TITLE
Respect half-open annotation intervals when stepping back

### DIFF
--- a/tools/apps/annotator/index.html
+++ b/tools/apps/annotator/index.html
@@ -844,7 +844,9 @@ function enabledTime(time, direction = 1) {
     time >= item.start && time < item.end && item.enabled === false,
   );
   if (!interval) return time;
-  return direction < 0 ? interval.start : interval.end;
+  // Intervals are [start, end): forward lands on end (the next segment's
+  // first frame), while backward lands on the prior frame outside this segment.
+  return direction < 0 ? Math.max(0, interval.start - 1 / FPS) : interval.end;
 }
 
 function seekEnabled(time, direction = 1) {


### PR DESCRIPTION
Annotation intervals are `[start, end)`: skipping forward lands on the next annotation at `end`; skipping backward now lands on the preceding video frame (`start - 1/FPS`) rather than the disabled interval's first frame.

Verified in Playwright with a disabled `[1.0, 2.0)` segment: forward lands at 2.0, backward at 0.966666 seconds.