### PR TITLE
Harden VGGT Omega batch recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,17 @@ npm run publish-web:fast   # skip scene uploads (annotation/list changes only)
 npm run dataset:verify
 ```
 
+Full publication deterministically gzip-compresses scene `.bin` point-cloud
+assets before upload. They keep their existing URLs and are stored with
+`Content-Encoding: gzip`, so browsers decode them transparently. Never upload
+gzip bytes without that metadata; the viewer expects decoded binary arrays.
+For a resumable migration of existing bucket objects, run:
+
+```bash
+python tools/publishing/gzip_scene_bins.py \
+  --invalidate-distribution E1FTYLW4OET6KU
+```
+
 Do not edit generated README rows or `tools/apps/annotator/catalog-videos.json` by hand.
 Annotation filenames use the same video stem with an `_annotations.json` suffix.
 

--- a/docs/vggt_scene_pipeline.md
+++ b/docs/vggt_scene_pipeline.md
@@ -51,6 +51,7 @@ scenes/
         f_000001.jpg
         ...
       vggt_scene.glb
+      scene_quality.json
       point_cloud.npz
       relative_path.csv
       camera_views/
@@ -74,6 +75,13 @@ setting, focal length, and camera-view render settings. `scene_state.json`
 stores interactive corrections such as a manually measured scale. The viewer
 directory is self-contained enough to serve the point cloud and frame
 comparison assets.
+
+`scene_quality.json` contains raw VGGT-Omega depth-confidence percentiles and
+per-frame median statistics. These are uncalibrated model scores: they are
+useful for ranking reconstructions produced with comparable settings, but are
+not probabilities or absolute guarantees of geometric accuracy. The same
+summary is embedded as `quality` in `scene_manifest.json`, `metadata.json`, and
+the scene catalog response.
 
 The default server output root is the repo root, so generated 3D scenes land in
 `scenes/`. Heavy video downloads remain cached outside the repo under
@@ -137,27 +145,22 @@ when the segments likely share scene overlap; otherwise they should be
 reconstructed as separate scenes. The dialog can preview the selected intervals
 in the source video so transitions can be checked before running VGGT.
 
-Frame extraction uses FFmpeg. The default crop preset is `central_clean`,
-restored from the manually selected clean crop used in the first high-quality
-VGGT overlay:
+Frame extraction uses FFmpeg. The default crop preset is an explicit `260x280`
+region centered on the previously validated clean view:
 
 ```text
-crop=x=iw*(120/848), y=ih*(190/478), w=iw*(660/848), h=ih*(280/478)
+crop=x=iw*(320/848), y=ih*(190/478), w=iw*(260/848), h=ih*(280/478)
 ```
 
-On the common `848x478` source videos, that is exactly `x=120, y=190, w=660,
-h=280`. It removes the side blur/rotor regions and the top HUD/propeller band
-while preserving the flight-relevant lower central view. Extracted frames are
-then scaled to the requested width. When an FPS is explicitly selected, all
-frames emitted by FFmpeg's `fps` filter are sent forward; there is no additional
-target-frame cap.
+On the common `848x478` source videos, that is exactly `x=320, y=190, w=260,
+h=280`. Extracted frames are then scaled to the requested width. When an FPS is
+explicitly selected, all frames emitted by FFmpeg's `fps` filter are sent
+forward; there is no additional target-frame cap.
 
-The backend also encodes the extracted frame sequence as `vggt_input.mp4`.
-For public VGGT Space uploads this MP4 is a transport wrapper, not the timing
-source: high-FPS extracted frames are packed into a 2 fps MP4, then VGGT samples
-that upload video at 2 fps so every extracted frame is still used. Real timing
-for speed/height remains in `frames.csv` via `video_time_s`, `segment_time_s`,
-and `sequence_time_s`.
+The backend uploads the extracted JPEGs directly to VGGT. It does not create an
+intermediate MP4, avoiding a second lossy encode and an artificial transport
+FPS. Real timing for speed/height remains in `frames.csv` via `video_time_s`,
+`segment_time_s`, and `sequence_time_s`.
 
 Default UI parameters:
 
@@ -165,7 +168,7 @@ Default UI parameters:
 - estimated image count: selected flight duration multiplied by sample FPS; this
   is informational when FPS is explicitly selected, not a cap
 - crop: `central_clean`
-- width: `660`
+- width: `260`
 - focal length for reprojection diagnostics: `812 px`
 - default scale: `117.6 m/unit`
 
@@ -176,6 +179,17 @@ VGGT.
 Tool:
 
 - `tools/server/fpv_tool_server.py`
+
+For repeatable quality experiments, the orchestration command exposes the two
+main sampling dimensions independently:
+
+```bash
+python tools/pipeline/reconstruct_scenes.py --frames 80 \
+  --tail-seconds 8 --exclude-tail-seconds 1 --preset clean <scene>
+```
+
+Without these overrides, the clean preset uses 125 adaptively selected frames
+from `[-13s, -1s]`.
 
 ### 3. VGGT Reconstruction
 

--- a/docs/vggt_scene_pipeline.md
+++ b/docs/vggt_scene_pipeline.md
@@ -87,6 +87,22 @@ The default server output root is the repo root, so generated 3D scenes land in
 `scenes/`. Heavy video downloads remain cached outside the repo under
 `/tmp/fpv-model-benchmark/videos`.
 
+## Scene Binary Publication
+
+`npm run publish-web` gzip-compresses `points_positions.bin` and
+`points_colors.bin` into `build/web/gzip-scenes/`, then uploads the compressed
+bytes under their original CloudFront keys with both:
+
+```text
+Content-Type: application/octet-stream
+Content-Encoding: gzip
+```
+
+The browser receives the same decoded bytes expected by the viewer. Do not
+rename these assets to `.gz`, and do not upload compressed bytes without the
+`Content-Encoding` metadata. The fast publishing command intentionally skips
+scene assets.
+
 ## Scene Browser
 
 The local server now exposes a scene dropdown:

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dataset:add": "node tools/catalog/dataset.mjs add",
     "dataset:annotate": "node tools/catalog/dataset.mjs annotate",
     "dataset:add-scene": "node tools/catalog/dataset.mjs add-scene",
+    "dataset:unpublish-scenes": "node tools/catalog/dataset.mjs unpublish-scenes",
     "dataset:rename": "node tools/catalog/dataset.mjs rename",
     "dataset:publish": "node tools/catalog/dataset.mjs publish",
     "dataset:verify": "node tools/catalog/dataset.mjs verify",

--- a/scene-manifests/2026-04-29_strike_on_merkava_tank/2026-04-29_strike_on_merkava_tank_seg01.json
+++ b/scene-manifests/2026-04-29_strike_on_merkava_tank/2026-04-29_strike_on_merkava_tank_seg01.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": 1,
-  "video_id": "2026-04-29_strike_on_merkava_tank",
-  "scene_id": "2026-04-29_strike_on_merkava_tank_seg01",
-  "path": "2026-04-29_strike_on_merkava_tank/2026-04-29_strike_on_merkava_tank_seg01",
-  "viewer_key": "scenes/2026-04-29_strike_on_merkava_tank/2026-04-29_strike_on_merkava_tank_seg01/viewer/scene_meta.json"
-}

--- a/scene-manifests/2026-05-01_strike_on_soldiers/2026-05-01_strike_on_soldiers_seg01_seg02_seg03.json
+++ b/scene-manifests/2026-05-01_strike_on_soldiers/2026-05-01_strike_on_soldiers_seg01_seg02_seg03.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": 1,
-  "video_id": "2026-05-01_strike_on_soldiers",
-  "scene_id": "2026-05-01_strike_on_soldiers_seg01_seg02_seg03",
-  "path": "2026-05-01_strike_on_soldiers/2026-05-01_strike_on_soldiers_seg01_seg02_seg03",
-  "viewer_key": "scenes/2026-05-01_strike_on_soldiers/2026-05-01_strike_on_soldiers_seg01_seg02_seg03/viewer/scene_meta.json"
-}

--- a/scene-manifests/2026-05-03_strike_on_surveillance_camera/2026-05-03_strike_on_surveillance_camera_seg04_seg05.json
+++ b/scene-manifests/2026-05-03_strike_on_surveillance_camera/2026-05-03_strike_on_surveillance_camera_seg04_seg05.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": 1,
-  "video_id": "2026-05-03_strike_on_surveillance_camera",
-  "scene_id": "2026-05-03_strike_on_surveillance_camera_seg04_seg05",
-  "path": "2026-05-03_strike_on_surveillance_camera/2026-05-03_strike_on_surveillance_camera_seg04_seg05",
-  "viewer_key": "scenes/2026-05-03_strike_on_surveillance_camera/2026-05-03_strike_on_surveillance_camera_seg04_seg05/viewer/scene_meta.json"
-}

--- a/scene-manifests/2026-05-18_brigade_300_commander_vehicle_shomera_mmirleb_16516/2026-05-18_brigade_300_commander_vehicle_shomera_mmirleb_16516_seg04.json
+++ b/scene-manifests/2026-05-18_brigade_300_commander_vehicle_shomera_mmirleb_16516/2026-05-18_brigade_300_commander_vehicle_shomera_mmirleb_16516_seg04.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": 1,
-  "video_id": "2026-05-18_brigade_300_commander_vehicle_shomera_mmirleb_16516",
-  "scene_id": "2026-05-18_brigade_300_commander_vehicle_shomera_mmirleb_16516_seg04",
-  "path": "2026-05-18_brigade_300_commander_vehicle_shomera_mmirleb_16516/2026-05-18_brigade_300_commander_vehicle_shomera_mmirleb_16516_seg04",
-  "viewer_key": "scenes/2026-05-18_brigade_300_commander_vehicle_shomera_mmirleb_16516/2026-05-18_brigade_300_commander_vehicle_shomera_mmirleb_16516_seg04/viewer/scene_meta.json"
-}

--- a/scene-manifests/2026-05-18_iron_dome_platform_shomera/2026-05-18_iron_dome_platform_shomera_seg01.json
+++ b/scene-manifests/2026-05-18_iron_dome_platform_shomera/2026-05-18_iron_dome_platform_shomera_seg01.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": 1,
-  "video_id": "2026-05-18_iron_dome_platform_shomera",
-  "scene_id": "2026-05-18_iron_dome_platform_shomera_seg01",
-  "path": "2026-05-18_iron_dome_platform_shomera/2026-05-18_iron_dome_platform_shomera_seg01",
-  "viewer_key": "scenes/2026-05-18_iron_dome_platform_shomera/2026-05-18_iron_dome_platform_shomera_seg01/viewer/scene_meta.json"
-}

--- a/scene-manifests/2026-05-27_enemy_vehicle_in_northern_settlement/2026-05-27_enemy_vehicle_in_northern_settlement_seg02_seg03.json
+++ b/scene-manifests/2026-05-27_enemy_vehicle_in_northern_settlement/2026-05-27_enemy_vehicle_in_northern_settlement_seg02_seg03.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": 1,
-  "video_id": "2026-05-27_enemy_vehicle_in_northern_settlement",
-  "scene_id": "2026-05-27_enemy_vehicle_in_northern_settlement_seg02_seg03",
-  "path": "2026-05-27_enemy_vehicle_in_northern_settlement/2026-05-27_enemy_vehicle_in_northern_settlement_seg02_seg03",
-  "viewer_key": "scenes/2026-05-27_enemy_vehicle_in_northern_settlement/2026-05-27_enemy_vehicle_in_northern_settlement_seg02_seg03/viewer/scene_meta.json"
-}

--- a/scene-manifests/2026-05-30_technical_equipment_rashaf_mmirleb_17060/2026-05-30_technical_equipment_rashaf_mmirleb_17060_seg01_seg02.json
+++ b/scene-manifests/2026-05-30_technical_equipment_rashaf_mmirleb_17060/2026-05-30_technical_equipment_rashaf_mmirleb_17060_seg01_seg02.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": 1,
-  "video_id": "2026-05-30_technical_equipment_rashaf_mmirleb_17060",
-  "scene_id": "2026-05-30_technical_equipment_rashaf_mmirleb_17060_seg01_seg02",
-  "path": "2026-05-30_technical_equipment_rashaf_mmirleb_17060/2026-05-30_technical_equipment_rashaf_mmirleb_17060_seg01_seg02",
-  "viewer_key": "scenes/2026-05-30_technical_equipment_rashaf_mmirleb_17060/2026-05-30_technical_equipment_rashaf_mmirleb_17060_seg01_seg02/viewer/scene_meta.json"
-}

--- a/scene-manifests/2026-06-01_soldiers_near_yahmor_al_shqif/2026-06-01_soldiers_near_yahmor_al_shqif_seg02_seg03.json
+++ b/scene-manifests/2026-06-01_soldiers_near_yahmor_al_shqif/2026-06-01_soldiers_near_yahmor_al_shqif_seg02_seg03.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": 1,
-  "video_id": "2026-06-01_soldiers_near_yahmor_al_shqif",
-  "scene_id": "2026-06-01_soldiers_near_yahmor_al_shqif_seg02_seg03",
-  "path": "2026-06-01_soldiers_near_yahmor_al_shqif/2026-06-01_soldiers_near_yahmor_al_shqif_seg02_seg03",
-  "viewer_key": "scenes/2026-06-01_soldiers_near_yahmor_al_shqif/2026-06-01_soldiers_near_yahmor_al_shqif_seg02_seg03/viewer/scene_meta.json"
-}

--- a/scene-manifests/2026-06-02_merkava_tank_near_yahmor_al_shqif/2026-06-02_merkava_tank_near_yahmor_al_shqif_seg01_seg02.json
+++ b/scene-manifests/2026-06-02_merkava_tank_near_yahmor_al_shqif/2026-06-02_merkava_tank_near_yahmor_al_shqif_seg01_seg02.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": 1,
-  "video_id": "2026-06-02_merkava_tank_near_yahmor_al_shqif",
-  "scene_id": "2026-06-02_merkava_tank_near_yahmor_al_shqif_seg01_seg02",
-  "path": "2026-06-02_merkava_tank_near_yahmor_al_shqif/2026-06-02_merkava_tank_near_yahmor_al_shqif_seg01_seg02",
-  "viewer_key": "scenes/2026-06-02_merkava_tank_near_yahmor_al_shqif/2026-06-02_merkava_tank_near_yahmor_al_shqif_seg01_seg02/viewer/scene_meta.json"
-}

--- a/scene-manifests/2026-06-02_namer_vehicle_near_yahmor_al_shqif/2026-06-02_namer_vehicle_near_yahmor_al_shqif_seg01_seg02.json
+++ b/scene-manifests/2026-06-02_namer_vehicle_near_yahmor_al_shqif/2026-06-02_namer_vehicle_near_yahmor_al_shqif_seg01_seg02.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": 1,
-  "video_id": "2026-06-02_namer_vehicle_near_yahmor_al_shqif",
-  "scene_id": "2026-06-02_namer_vehicle_near_yahmor_al_shqif_seg01_seg02",
-  "path": "2026-06-02_namer_vehicle_near_yahmor_al_shqif/2026-06-02_namer_vehicle_near_yahmor_al_shqif_seg01_seg02",
-  "viewer_key": "scenes/2026-06-02_namer_vehicle_near_yahmor_al_shqif/2026-06-02_namer_vehicle_near_yahmor_al_shqif_seg01_seg02/viewer/scene_meta.json"
-}

--- a/scene-manifests/2026-06-02_soldiers_and_namer_vehicle_near_yahmor_al_shqif/2026-06-02_soldiers_and_namer_vehicle_near_yahmor_al_shqif_seg01_seg02_seg03.json
+++ b/scene-manifests/2026-06-02_soldiers_and_namer_vehicle_near_yahmor_al_shqif/2026-06-02_soldiers_and_namer_vehicle_near_yahmor_al_shqif_seg01_seg02_seg03.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": 1,
-  "video_id": "2026-06-02_soldiers_and_namer_vehicle_near_yahmor_al_shqif",
-  "scene_id": "2026-06-02_soldiers_and_namer_vehicle_near_yahmor_al_shqif_seg01_seg02_seg03",
-  "path": "2026-06-02_soldiers_and_namer_vehicle_near_yahmor_al_shqif/2026-06-02_soldiers_and_namer_vehicle_near_yahmor_al_shqif_seg01_seg02_seg03",
-  "viewer_key": "scenes/2026-06-02_soldiers_and_namer_vehicle_near_yahmor_al_shqif/2026-06-02_soldiers_and_namer_vehicle_near_yahmor_al_shqif_seg01_seg02_seg03/viewer/scene_meta.json"
-}

--- a/scene-manifests/2026-06-06_merkava_tank_blat_position/2026-06-06_merkava_tank_blat_position_seg06_seg07.json
+++ b/scene-manifests/2026-06-06_merkava_tank_blat_position/2026-06-06_merkava_tank_blat_position_seg06_seg07.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": 1,
-  "video_id": "2026-06-06_merkava_tank_blat_position",
-  "scene_id": "2026-06-06_merkava_tank_blat_position_seg06_seg07",
-  "path": "2026-06-06_merkava_tank_blat_position/2026-06-06_merkava_tank_blat_position_seg06_seg07",
-  "viewer_key": "scenes/2026-06-06_merkava_tank_blat_position/2026-06-06_merkava_tank_blat_position_seg06_seg07/viewer/scene_meta.json"
-}

--- a/scene-manifests/2026-06-06_sholef_howitzer_adaissah/2026-06-06_sholef_howitzer_adaissah_seg02_seg03.json
+++ b/scene-manifests/2026-06-06_sholef_howitzer_adaissah/2026-06-06_sholef_howitzer_adaissah_seg02_seg03.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": 1,
-  "video_id": "2026-06-06_sholef_howitzer_adaissah",
-  "scene_id": "2026-06-06_sholef_howitzer_adaissah_seg02_seg03",
-  "path": "2026-06-06_sholef_howitzer_adaissah/2026-06-06_sholef_howitzer_adaissah_seg02_seg03",
-  "viewer_key": "scenes/2026-06-06_sholef_howitzer_adaissah/2026-06-06_sholef_howitzer_adaissah_seg02_seg03/viewer/scene_meta.json"
-}

--- a/scene-manifests/2026-06-08_command_and_control_vehicle_beaufort_castle/2026-06-08_command_and_control_vehicle_beaufort_castle_seg01_seg02.json
+++ b/scene-manifests/2026-06-08_command_and_control_vehicle_beaufort_castle/2026-06-08_command_and_control_vehicle_beaufort_castle_seg01_seg02.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": 1,
-  "video_id": "2026-06-08_command_and_control_vehicle_beaufort_castle",
-  "scene_id": "2026-06-08_command_and_control_vehicle_beaufort_castle_seg01_seg02",
-  "path": "2026-06-08_command_and_control_vehicle_beaufort_castle/2026-06-08_command_and_control_vehicle_beaufort_castle_seg01_seg02",
-  "viewer_key": "scenes/2026-06-08_command_and_control_vehicle_beaufort_castle/2026-06-08_command_and_control_vehicle_beaufort_castle_seg01_seg02/viewer/scene_meta.json"
-}

--- a/scene-manifests/2026-06-10_humvee_yahmar_al_shaqif/2026-06-10_humvee_yahmar_al_shaqif_seg02_seg03.json
+++ b/scene-manifests/2026-06-10_humvee_yahmar_al_shaqif/2026-06-10_humvee_yahmar_al_shaqif_seg02_seg03.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": 1,
-  "video_id": "2026-06-10_humvee_yahmar_al_shaqif",
-  "scene_id": "2026-06-10_humvee_yahmar_al_shaqif_seg02_seg03",
-  "path": "2026-06-10_humvee_yahmar_al_shaqif/2026-06-10_humvee_yahmar_al_shaqif_seg02_seg03",
-  "viewer_key": "scenes/2026-06-10_humvee_yahmar_al_shaqif/2026-06-10_humvee_yahmar_al_shaqif_seg02_seg03/viewer/scene_meta.json"
-}

--- a/scene-manifests/2026-06-13_excavator_majdal_zoun/2026-06-13_excavator_majdal_zoun_seg02_seg03.json
+++ b/scene-manifests/2026-06-13_excavator_majdal_zoun/2026-06-13_excavator_majdal_zoun_seg02_seg03.json
@@ -1,7 +1,0 @@
-{
-  "schema_version": 1,
-  "video_id": "2026-06-13_excavator_majdal_zoun",
-  "scene_id": "2026-06-13_excavator_majdal_zoun_seg02_seg03",
-  "path": "2026-06-13_excavator_majdal_zoun/2026-06-13_excavator_majdal_zoun_seg02_seg03",
-  "viewer_key": "scenes/2026-06-13_excavator_majdal_zoun/2026-06-13_excavator_majdal_zoun_seg02_seg03/viewer/scene_meta.json"
-}

--- a/tools/apps/annotator/index.html
+++ b/tools/apps/annotator/index.html
@@ -413,7 +413,7 @@ kbd{background:var(--surf2);border:1px solid var(--border);border-radius:3px;
             </select>
           </label>
           <label>Width
-            <input id="sceneWidth" type="number" min="0" max="1920" step="10" value="660">
+            <input id="sceneWidth" type="number" min="0" max="1920" step="10" value="260">
           </label>
         </div>
       </section>
@@ -503,9 +503,9 @@ let videoStatuses = {};
 let scenePreviewQueue = [];
 let scenePreviewIndex = -1;
 const CENTRAL_CLEAN_CROP = {
-  x: 120 / 848,
+  x: 320 / 848,
   y: 190 / 478,
-  w: 660 / 848,
+  w: 260 / 848,
   h: 280 / 478,
 };
 
@@ -1510,7 +1510,7 @@ function sceneRequestBody() {
     target_frames: 0,
     default_scale_m_per_unit: Number(g('sceneDefaultScale').value) || 117.6,
     crop_preset: g('sceneCropPreset').value,
-    width: Number(g('sceneWidth').value) || 660,
+    width: Number(g('sceneWidth').value) || 260,
     focal_px: 812,
     refresh_vggt: true,
     render_camera_views: true,

--- a/tools/catalog/dataset.mjs
+++ b/tools/catalog/dataset.mjs
@@ -42,6 +42,36 @@ function aws(args) {
   run("aws", args);
 }
 
+async function invalidate(distributionId, paths) {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const result = spawnSync(
+      "aws",
+      ["cloudfront", "create-invalidation", "--distribution-id", distributionId, "--paths", ...paths],
+      { cwd: root, encoding: "utf8" },
+    );
+    if (result.status === 0) return JSON.parse(result.stdout).Invalidation.Id;
+
+    const message = result.stderr || "cloudfront invalidation failed";
+    if (!message.includes("TooManyInvalidationsInProgress") || attempt === 2) throw new Error(message);
+
+    const active = spawnSync(
+      "aws",
+      ["cloudfront", "list-invalidations", "--distribution-id", distributionId, "--output", "json"],
+      { cwd: root, encoding: "utf8" },
+    );
+    if (active.status !== 0) throw new Error(active.stderr || "could not list CloudFront invalidations");
+    const inProgress = JSON.parse(active.stdout).InvalidationList?.Items?.filter((item) => item.Status === "InProgress") ?? [];
+    if (!inProgress.length) {
+      await new Promise((resolve) => setTimeout(resolve, 5000));
+      continue;
+    }
+    console.log(`CloudFront invalidation capacity is full; waiting for ${inProgress.length} in-progress invalidation(s)`);
+    for (const invalidation of inProgress) {
+      aws(["cloudfront", "wait", "invalidation-completed", "--distribution-id", distributionId, "--id", invalidation.Id]);
+    }
+  }
+}
+
 async function verifyUrl(url, attempts = 5) {
   for (let attempt = 0; attempt < attempts; attempt += 1) {
     const response = await fetch(`${url}${url.includes("?") ? "&" : "?"}verify=${Date.now()}`, {
@@ -52,6 +82,14 @@ async function verifyUrl(url, attempts = 5) {
     if (attempt === attempts - 1) throw new Error(`${url} returned HTTP ${response.status}`);
     await new Promise((resolve) => setTimeout(resolve, 1000 * 2 ** attempt));
   }
+}
+
+function sceneIds(opts) {
+  const value = opts.ids ?? opts.id;
+  if (!value || typeof value !== "string") throw new Error("--id or --ids is required");
+  const ids = [...new Set(value.split(",").map((id) => id.trim()).filter(Boolean))];
+  if (!ids.length) throw new Error("at least one scene ID is required");
+  return ids;
 }
 
 function loadState() {
@@ -144,6 +182,58 @@ function addScene(opts) {
   console.log(`registered scene ${sceneId}; run dataset:publish with this local scenes directory present`);
 }
 
+async function unpublishScenes(opts) {
+  const ids = sceneIds(opts);
+  const state = loadState();
+  const catalogIds = new Set(state.catalog.videos.map((video) => video.id));
+  const unknown = ids.filter((id) => !catalogIds.has(id));
+  if (unknown.length) throw new Error(`unknown catalog IDs: ${unknown.join(", ")}`);
+
+  const manifestUrl = `${CDN_BASE}/data/videos.json?unpublish=${Date.now()}`;
+  const response = await fetch(manifestUrl);
+  if (!response.ok) throw new Error(`could not fetch current web manifest: HTTP ${response.status}`);
+  const current = await response.json();
+  const selected = new Set(ids);
+  const videos = (current.videos ?? []).map((video) => (
+    selected.has(video.slug) ? { ...video, scenePath: null, sceneQuality: null } : video
+  ));
+  const removedReferences = videos.filter((video) => selected.has(video.slug) && video.scenePath === null).length;
+  if (removedReferences !== ids.length) throw new Error("current web manifest is missing one or more requested videos");
+
+  const localManifests = ids.filter((id) => fs.existsSync(path.join(root, "scene-manifests", id)));
+  console.log(`will unpublish ${ids.length} scene(s); remove ${localManifests.length} tracked scene-manifest director${localManifests.length === 1 ? "y" : "ies"}`);
+  if (!opts.execute) {
+    console.log("dry run only; rerun with --execute to update CloudFront and delete scene assets");
+    return;
+  }
+
+  for (const id of localManifests) fs.rmSync(path.join(root, "scene-manifests", id), { recursive: true });
+  fs.mkdirSync(path.join(root, "build", "web"), { recursive: true });
+  writeJson(path.join(root, "build", "web", "current-videos.json"), { ...current, videos });
+  run("node", ["tools/publishing/build_web_data.mjs"]);
+
+  const published = readJson(path.join(root, "build", "web", "videos.json"));
+  const publishedById = new Map(published.videos.map((video) => [video.slug, video]));
+  for (const id of ids) {
+    const video = publishedById.get(id);
+    if (!video || video.scenePath !== null) throw new Error(`${id}: generated manifest still references a scene`);
+  }
+
+  aws(["s3", "cp", "build/web/videos.json", `${bucket}/data/videos.json`, "--content-type", "application/json", "--cache-control", "public,max-age=300"]);
+  const distributionId = opts["distribution-id"] ?? "E1FTYLW4OET6KU";
+  const manifestInvalidation = await invalidate(distributionId, ["/data/videos.json"]);
+  aws(["cloudfront", "wait", "invalidation-completed", "--distribution-id", distributionId, "--id", manifestInvalidation]);
+  await verifyUrl(`${CDN_BASE}/data/videos.json`);
+
+  for (const id of ids) aws(["s3", "rm", `${bucket}/scenes/${id}/`, "--recursive"]);
+  const scenePaths = ids.map((id) => `/scenes/${id}/*`);
+  for (let offset = 0; offset < scenePaths.length; offset += 15) {
+    const sceneInvalidation = await invalidate(distributionId, scenePaths.slice(offset, offset + 15));
+    aws(["cloudfront", "wait", "invalidation-completed", "--distribution-id", distributionId, "--id", sceneInvalidation]);
+  }
+  console.log(`unpublished ${ids.length} scene(s); videos and annotations were not changed`);
+}
+
 function replaceStrings(value, from, to) {
   if (typeof value === "string") return value.split(from).join(to);
   if (Array.isArray(value)) return value.map((item) => replaceStrings(item, from, to));
@@ -221,6 +311,7 @@ function help() {
   npm run dataset:add -- --video FILE --thumbnail FILE --metadata JSON [--no-upload]
   npm run dataset:annotate -- --id ID --annotation JSON
   npm run dataset:add-scene -- --id ID --scene DIR
+  npm run dataset:unpublish-scenes -- --ids ID,ID [--execute]
   npm run dataset:rename -- --from ID --to ID --reason TEXT [--review-after DATE] --execute
   npm run dataset:publish
   npm run dataset:verify`);
@@ -230,6 +321,7 @@ const opts = options(rawArgs);
 if (command === "add") await add(opts);
 else if (command === "annotate") annotate(opts);
 else if (command === "add-scene") addScene(opts);
+else if (command === "unpublish-scenes") await unpublishScenes(opts);
 else if (command === "rename") await rename(opts);
 else if (command === "publish") run("bash", ["tools/publishing/publish_web.sh", ...(opts["skip-scenes"] ? ["--skip-scenes"] : [])]);
 else if (command === "verify") {

--- a/tools/pipeline/README.md
+++ b/tools/pipeline/README.md
@@ -10,3 +10,23 @@ The primary orchestration entry points are:
 - `flight_path_pipeline.py` for reusable flight-path reconstruction
 - `reconstruct_scenes.py` and `run_vggt_batch_from_annotations.py` for scenes
 - `auto_scale_hypotheses.py` for metric-scale hypotheses
+
+## Resumable Omega Runs
+
+Use the wrapper for a long Omega batch. It starts the local tool server with
+the same output root as the batch, checkpoints one result row per resolved
+scene, and clears only Omega's transient `demo_outputs/input_images_*` upload
+directories between sequential jobs. It never removes scene outputs, job
+records, checkpoints, or model weights.
+
+```bash
+python tools/pipeline/reconstruct_scenes.py --preset clean --skip-existing --stop-pod \
+  2026-05-26_anti_drone_platform_biranit
+```
+
+Pass `--out-dir /path/to/output-root` when the local server and generated
+scenes are intentionally outside this checkout. The command stores its ledger
+at `<out-dir>/scenes/.batch_<preset>.json`; rerunning it updates rows by scene
+id, so successful retries replace old error rows instead of accumulating stale
+totals. Use `--reset-results` only with `run_vggt_batch_from_annotations.py`
+when deliberately starting a new ledger.

--- a/tools/pipeline/create_vggt_threejs_viewer.py
+++ b/tools/pipeline/create_vggt_threejs_viewer.py
@@ -348,6 +348,17 @@ def load_sample_fps(video_dir: Path) -> float | None:
     return value if value > 0 else None
 
 
+def load_quality(video_dir: Path) -> dict | None:
+    for path in [video_dir / "scene_quality.json", video_dir / "metadata.json"]:
+        if not path.exists():
+            continue
+        data = json.loads(path.read_text())
+        quality = data if path.name == "scene_quality.json" else data.get("quality")
+        if isinstance(quality, dict):
+            return quality
+    return None
+
+
 def main() -> None:
     args = parse_args()
     args.out_dir.mkdir(parents=True, exist_ok=True)
@@ -388,6 +399,7 @@ def main() -> None:
         "scene_state_url": args.state_url or "",
         "default_scale_m_per_unit": args.default_scale_m_per_unit,
         "sample_fps": sample_fps,
+        "quality": load_quality(args.video_dir),
         "point_count": int(len(points)),
         "bbox_min": bbox_min.astype(float).tolist(),
         "bbox_max": bbox_max.astype(float).tolist(),

--- a/tools/pipeline/flight_path_pipeline.py
+++ b/tools/pipeline/flight_path_pipeline.py
@@ -590,6 +590,7 @@ def run_vggt(args: argparse.Namespace) -> None:
                     api_name="/update_gallery_on_upload",
                 )
         print(f"[vggt] target_dir={target_dir}; preview_frames={len(preview) if preview else 0}", flush=True)
+        (video_dir / "vggt_target_dir.txt").write_text(str(target_dir).strip() + "\n")
         t0 = time.time()
         if args.backend == "classic":
             job = client.submit(
@@ -1279,7 +1280,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--vggt-timeout", type=int, default=900)
     p.add_argument("--hf-token-env", default="HF_TOKEN")
     p.add_argument("--backend", choices=["omega", "classic"], default="omega")
-    p.add_argument("--upload-mode", choices=["auto", "images", "video"], default="auto")
+    p.add_argument("--upload-mode", choices=["auto", "images", "video"], default="images")
     p.add_argument("--video-sample-fps", type=float, default=10.0)
     p.add_argument("--mask-sky", action="store_true", help="Enable the Space sky-segmentation mask before reconstruction")
     p.add_argument("--mask-black-bg", action="store_true", help="Tell the Space to drop the pure-black background (painted exclusion masks)")

--- a/tools/pipeline/omega_pod.py
+++ b/tools/pipeline/omega_pod.py
@@ -17,6 +17,7 @@ Environment overrides:
 
 Usage:
   python tools/pipeline/omega_pod.py up      # start pod + launch Omega, wait until ready
+  python tools/pipeline/omega_pod.py cleanup # clear stale Gradio demo uploads between jobs
   python tools/pipeline/omega_pod.py down    # stop the pod
   python tools/pipeline/omega_pod.py status  # print pod + gradio state
   python tools/pipeline/omega_pod.py url     # print the gradio space URL
@@ -62,12 +63,16 @@ def _runpodctl(*args: str) -> subprocess.CompletedProcess:
 
 
 def pod_start(pod_id: str = POD_ID) -> None:
-    _runpodctl("pod", "start", pod_id)
+    result = _runpodctl("pod", "start", pod_id)
+    if result.returncode:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "runpodctl pod start failed")
     log(f"pod {pod_id} start requested")
 
 
 def pod_stop(pod_id: str = POD_ID) -> None:
-    _runpodctl("pod", "stop", pod_id)
+    result = _runpodctl("pod", "stop", pod_id)
+    if result.returncode:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "runpodctl pod stop failed")
     log(f"pod {pod_id} stop requested")
 
 
@@ -78,6 +83,8 @@ def ssh_info(pod_id: str = POD_ID) -> dict | None:
     after a restart, so we use the direct ip:port endpoint runpodctl reports.
     """
     res = _runpodctl("ssh", "info", pod_id)
+    if res.returncode:
+        return None
     try:
         info = json.loads(res.stdout)
     except json.JSONDecodeError:
@@ -141,6 +148,26 @@ def launch_omega(info: dict) -> None:
         pass
 
 
+def cleanup_demo_outputs(info: dict) -> None:
+    """Free transient Gradio uploads without touching checkpoints or the app.
+
+    Omega writes every upload below ``demo_outputs/input_images_*``. They are
+    safe to remove only between requests; ``up`` calls this before app.py is
+    launched, and the standalone command is for a paused batch.
+    """
+    remote = (
+        f"mkdir -p {OMEGA_DIR}/demo_outputs && "
+        f"find {OMEGA_DIR}/demo_outputs -mindepth 1 -maxdepth 1 "
+        "-type d -name 'input_images_*' -exec rm -rf {} + && "
+        "df -h /workspace"
+    )
+    result = ssh_run(info, remote, timeout=120)
+    if result.returncode:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "Omega cache cleanup failed")
+    for line in result.stdout.splitlines():
+        log(f"workspace: {line}")
+
+
 def wait_gradio(pod_id: str, timeout_s: int) -> bool:
     deadline = time.time() + timeout_s
     while time.time() < deadline:
@@ -150,7 +177,7 @@ def wait_gradio(pod_id: str, timeout_s: int) -> bool:
     return False
 
 
-def up(pod_id: str = POD_ID, ready_timeout_s: int = 600) -> str:
+def up(pod_id: str = POD_ID, ready_timeout_s: int = 600, *, clean_cache: bool = True) -> str:
     """Ensure the pod is running and Omega answers on the gradio port."""
     if gradio_status(pod_id) == 200:
         log(f"gradio already up at {space_url(pod_id)}")
@@ -168,6 +195,10 @@ def up(pod_id: str = POD_ID, ready_timeout_s: int = 600) -> str:
     if gradio_status(pod_id) == 200:
         log("gradio already serving")
         return space_url(pod_id)
+
+    if clean_cache:
+        log("clearing stale demo uploads before launch")
+        cleanup_demo_outputs(info)
 
     log("launching Omega app.py ...")
     launch_omega(info)
@@ -187,19 +218,25 @@ def status(pod_id: str = POD_ID) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("command", choices=["up", "down", "status", "url"])
+    parser.add_argument("command", choices=["up", "down", "status", "url", "cleanup"])
     parser.add_argument("--pod-id", default=POD_ID)
     parser.add_argument("--ready-timeout", type=int, default=600, help="seconds to wait for SSH / gradio")
+    parser.add_argument("--no-clean-cache", action="store_true", help="do not clear stale demo uploads before a fresh launch")
     args = parser.parse_args()
 
     if args.command == "up":
-        print(up(args.pod_id, ready_timeout_s=args.ready_timeout))
+        print(up(args.pod_id, ready_timeout_s=args.ready_timeout, clean_cache=not args.no_clean_cache))
     elif args.command == "down":
         pod_stop(args.pod_id)
     elif args.command == "status":
         status(args.pod_id)
     elif args.command == "url":
         print(space_url(args.pod_id))
+    elif args.command == "cleanup":
+        info = wait_ssh(args.pod_id, timeout_s=args.ready_timeout)
+        if not info:
+            raise SystemExit("[omega-pod] SSH did not become reachable; cannot clean demo outputs")
+        cleanup_demo_outputs(info)
     return 0
 
 

--- a/tools/pipeline/omega_pod.py
+++ b/tools/pipeline/omega_pod.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import posixpath
+import shlex
 import subprocess
 import sys
 import time
@@ -168,6 +170,79 @@ def cleanup_demo_outputs(info: dict) -> None:
         log(f"workspace: {line}")
 
 
+def confidence_summary(info: dict, target_dir: str, percentile: float = 50.0) -> dict:
+    """Summarize Omega's raw depth confidence without copying predictions.npz."""
+    target_dir = target_dir.strip()
+    if not target_dir:
+        raise ValueError("empty Omega target directory")
+    remote_dir = target_dir if target_dir.startswith("/") else posixpath.join(OMEGA_DIR, target_dir)
+    remote_dir = posixpath.normpath(remote_dir)
+    omega_root = posixpath.normpath(OMEGA_DIR)
+    if remote_dir != omega_root and not remote_dir.startswith(omega_root + "/"):
+        raise ValueError(f"Omega target directory is outside {OMEGA_DIR}: {target_dir}")
+    predictions_path = posixpath.join(remote_dir, "predictions.npz")
+    script = r'''
+import json
+import sys
+import numpy as np
+
+path = sys.argv[1]
+percentile = float(sys.argv[2])
+with np.load(path) as predictions:
+    confidence = np.asarray(predictions["depth_conf"])
+confidence = np.squeeze(confidence)
+if confidence.ndim < 2:
+    raise SystemExit(f"unexpected depth_conf shape: {confidence.shape}")
+if confidence.ndim == 2:
+    confidence = confidence[None, ...]
+finite = np.isfinite(confidence)
+values = confidence[finite]
+if values.size == 0:
+    raise SystemExit("depth_conf contains no finite values")
+frame_medians = []
+for frame in confidence:
+    frame_values = frame[np.isfinite(frame)]
+    frame_medians.append(float(np.median(frame_values)) if frame_values.size else None)
+valid_frame_medians = np.asarray([value for value in frame_medians if value is not None])
+def rounded(value):
+    return round(float(value), 6)
+summary = {
+    "schema_version": 1,
+    "metric": "vggt_omega_depth_confidence",
+    "calibration": "uncalibrated_model_score",
+    "higher_is_better": True,
+    "frames": int(confidence.shape[0]),
+    "finite_fraction": rounded(finite.mean()),
+    "confidence": {
+        "mean": rounded(values.mean()),
+        "p10": rounded(np.percentile(values, 10)),
+        "p25": rounded(np.percentile(values, 25)),
+        "median": rounded(np.median(values)),
+        "p75": rounded(np.percentile(values, 75)),
+        "p90": rounded(np.percentile(values, 90)),
+    },
+    "frame_median": {
+        "minimum": rounded(valid_frame_medians.min()),
+        "p10": rounded(np.percentile(valid_frame_medians, 10)),
+        "median": rounded(np.median(valid_frame_medians)),
+    },
+    "visualization_filter": {
+        "percentile": percentile,
+        "confidence_threshold": rounded(np.percentile(values, percentile)),
+    },
+}
+print(json.dumps(summary, separators=(",", ":")))
+'''
+    command = (
+        f"{shlex.quote(OMEGA_PYTHON)} -c {shlex.quote(script)} "
+        f"{shlex.quote(predictions_path)} {float(percentile):g}"
+    )
+    result = ssh_run(info, command, timeout=120)
+    if result.returncode:
+        raise RuntimeError(result.stderr.strip() or result.stdout.strip() or "confidence summary failed")
+    return json.loads(result.stdout.strip().splitlines()[-1])
+
+
 def wait_gradio(pod_id: str, timeout_s: int) -> bool:
     deadline = time.time() + timeout_s
     while time.time() < deadline:
@@ -218,10 +293,12 @@ def status(pod_id: str = POD_ID) -> None:
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("command", choices=["up", "down", "status", "url", "cleanup"])
+    parser.add_argument("command", choices=["up", "down", "status", "url", "cleanup", "confidence"])
     parser.add_argument("--pod-id", default=POD_ID)
     parser.add_argument("--ready-timeout", type=int, default=600, help="seconds to wait for SSH / gradio")
     parser.add_argument("--no-clean-cache", action="store_true", help="do not clear stale demo uploads before a fresh launch")
+    parser.add_argument("--target-dir", help="Omega demo output directory for the confidence command")
+    parser.add_argument("--percentile", type=float, default=50.0, help="visualization confidence percentile to report")
     args = parser.parse_args()
 
     if args.command == "up":
@@ -237,6 +314,13 @@ def main() -> int:
         if not info:
             raise SystemExit("[omega-pod] SSH did not become reachable; cannot clean demo outputs")
         cleanup_demo_outputs(info)
+    elif args.command == "confidence":
+        if not args.target_dir:
+            parser.error("confidence requires --target-dir")
+        info = ssh_info(args.pod_id)
+        if not info:
+            raise SystemExit("[omega-pod] SSH is not reachable; cannot read confidence")
+        print(json.dumps(confidence_summary(info, args.target_dir, args.percentile), separators=(",", ":")))
     return 0
 
 

--- a/tools/pipeline/reconstruct_scenes.py
+++ b/tools/pipeline/reconstruct_scenes.py
@@ -48,10 +48,12 @@ SERVER_URL = os.environ.get("FPV_SERVER_URL", "http://127.0.0.1:8766")
 
 # Named reconstruction presets -> extra flags for run_vggt_batch_from_annotations.
 # "clean" is the winning config: tight clean-centre crop, no black masks, Omega's
-# own sky mask, sequence CLAHE, adaptive 125-frame keyframing, last 12s.
+# own sky mask, sequence CLAHE, adaptive 125-frame keyframing, and the 12-second
+# interval ending one second before impact: [-13s, -1s].
 PRESETS: dict[str, list[str]] = {
     "clean": [
         "--tail-seconds", "12",
+        "--exclude-tail-seconds", "1",
         "--crop-preset", "central_clean",
         "--width", "660",
         "--no-masks",
@@ -61,6 +63,7 @@ PRESETS: dict[str, list[str]] = {
     ],
     "full-frame-skyseg": [
         "--tail-seconds", "12",
+        "--exclude-tail-seconds", "1",
         "--crop-preset", "full_frame",
         "--width", "720",
         "--adaptive-fps",

--- a/tools/pipeline/reconstruct_scenes.py
+++ b/tools/pipeline/reconstruct_scenes.py
@@ -47,15 +47,15 @@ SERVER_PYTHON = os.environ.get("FPV_SERVER_PYTHON", "/tmp/fpv-model-benchmark/ve
 SERVER_URL = os.environ.get("FPV_SERVER_URL", "http://127.0.0.1:8766")
 
 # Named reconstruction presets -> extra flags for run_vggt_batch_from_annotations.
-# "clean" is the winning config: tight clean-centre crop, no black masks, Omega's
-# own sky mask, sequence CLAHE, adaptive 125-frame keyframing, and the 12-second
+# "clean" is the current baseline: explicit 260x280 clean-centre crop, no black
+# masks, Omega's own sky mask, sequence CLAHE, adaptive 125-frame keyframing, and the 12-second
 # interval ending one second before impact: [-13s, -1s].
 PRESETS: dict[str, list[str]] = {
     "clean": [
         "--tail-seconds", "12",
         "--exclude-tail-seconds", "1",
         "--crop-preset", "central_clean",
-        "--width", "660",
+        "--width", "260",
         "--no-masks",
         "--adaptive-fps",
         "--clahe",
@@ -71,6 +71,24 @@ PRESETS: dict[str, list[str]] = {
         "--client-sky-seg",
     ],
 }
+
+
+def reconstruction_flags(args: argparse.Namespace) -> list[str]:
+    """Apply experiment overrides after the named preset defaults."""
+    flags = list(PRESETS[args.preset])
+    def set_value(name: str, value: object) -> None:
+        if name in flags:
+            flags[flags.index(name) + 1] = str(value)
+        else:
+            flags.extend([name, str(value)])
+
+    if args.tail_seconds is not None:
+        set_value("--tail-seconds", args.tail_seconds)
+    if args.exclude_tail_seconds is not None:
+        set_value("--exclude-tail-seconds", args.exclude_tail_seconds)
+    if args.frames is not None:
+        set_value("--adaptive-target", args.frames)
+    return flags
 
 
 def log(msg: str) -> None:
@@ -157,7 +175,8 @@ def run_batch(annotations: list[Path], preset_flags: list[str], args: argparse.N
         "--annotations", *[str(a) for a in annotations],
         "--vggt-space", space,
         "--vggt-backend", "omega",
-        "--vggt-upload-mode", "video",
+        "--vggt-upload-mode", "images",
+        "--omega-pod-id", args.pod_id,
         "--continue-on-error",
         "--poll-seconds", str(args.poll_seconds),
         "--vggt-timeout", str(args.vggt_timeout),
@@ -191,12 +210,22 @@ def main() -> int:
     parser.add_argument("--ready-timeout", type=int, default=600)
     parser.add_argument("--poll-seconds", type=int, default=30)
     parser.add_argument("--vggt-timeout", type=int, default=1800)
+    parser.add_argument("--frames", type=int, help="override the preset's adaptive VGGT frame count")
+    parser.add_argument("--tail-seconds", type=float, help="override how many seconds to keep before the excluded tail")
+    parser.add_argument("--exclude-tail-seconds", type=float, help="override seconds omitted from the end of the selected flight")
     parser.add_argument("--results-file", type=Path, default=None)
     parser.add_argument("--dry-run", action="store_true", help="resolve scenes and print the plan, then exit")
     args = parser.parse_args()
+    if args.frames is not None and args.frames < 1:
+        parser.error("--frames must be at least 1")
+    if args.tail_seconds is not None and args.tail_seconds <= 0:
+        parser.error("--tail-seconds must be greater than zero")
+    if args.exclude_tail_seconds is not None and args.exclude_tail_seconds < 0:
+        parser.error("--exclude-tail-seconds must be zero or greater")
 
     annotations = [resolve_annotation(s) for s in args.scenes]
-    log(f"preset={args.preset} scenes:")
+    preset_flags = reconstruction_flags(args)
+    log(f"preset={args.preset} flags={' '.join(preset_flags)} scenes:")
     for a in annotations:
         print(f"    {os.path.relpath(a, ROOT)}")
     if args.dry_run:
@@ -211,7 +240,7 @@ def main() -> int:
         log(f"skipping pod management; using {space}")
 
     try:
-        rc = run_batch(annotations, PRESETS[args.preset], args, space)
+        rc = run_batch(annotations, preset_flags, args, space)
     finally:
         if args.use_pod and args.stop_pod:
             log("stopping pod")

--- a/tools/pipeline/reconstruct_scenes.py
+++ b/tools/pipeline/reconstruct_scenes.py
@@ -36,9 +36,9 @@ from pathlib import Path
 
 import omega_pod
 
-ROOT = Path(__file__).resolve().parent.parent
+ROOT = Path(__file__).resolve().parents[2]
 ANNOTATION_DIR = ROOT / "annotations"
-BATCH_SCRIPT = ROOT / "tools" / "run_vggt_batch_from_annotations.py"
+BATCH_SCRIPT = ROOT / "tools" / "pipeline" / "run_vggt_batch_from_annotations.py"
 SERVER_SCRIPT = ROOT / "tools" / "server" / "fpv_tool_server.py"
 
 # The frame-extraction server needs cv2 / onnxruntime; point at whatever
@@ -74,17 +74,26 @@ def log(msg: str) -> None:
     print(f"[reconstruct] {msg}", flush=True)
 
 
-def server_up(url: str) -> bool:
+def server_output_root(url: str) -> Path | None:
     try:
-        with urllib.request.urlopen(url + "/api/scenes", timeout=5):
-            return True
+        with urllib.request.urlopen(url + "/api/health", timeout=5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        out_dir = payload.get("out_dir")
+        return Path(out_dir).resolve() if payload.get("ok") and out_dir else None
     except Exception:
-        return False
+        return None
 
 
-def ensure_local_server(url: str, start: bool) -> None:
-    if server_up(url):
-        log(f"local server up at {url}")
+def ensure_local_server(url: str, start: bool, out_dir: Path) -> None:
+    running_out_dir = server_output_root(url)
+    if running_out_dir:
+        expected_out_dir = out_dir.resolve()
+        if running_out_dir != expected_out_dir:
+            raise SystemExit(
+                f"[reconstruct] local server at {url} writes to {running_out_dir}, but this batch uses "
+                f"{expected_out_dir}. Restart it with --out-dir {expected_out_dir}, or use the matching --out-dir."
+            )
+        log(f"local server up at {url} with output root {running_out_dir}")
         return
     if not start:
         raise SystemExit(f"[reconstruct] local server not reachable at {url} (start it or drop --no-start-server)")
@@ -96,14 +105,14 @@ def ensure_local_server(url: str, start: bool) -> None:
     host = url.split("//", 1)[-1]
     hostname, _, port = host.partition(":")
     port = port or "8766"
-    log(f"starting local server: {SERVER_PYTHON} {SERVER_SCRIPT} --host {hostname} --port {port}")
+    log(f"starting local server: {SERVER_PYTHON} {SERVER_SCRIPT} --host {hostname} --port {port} --out-dir {out_dir}")
     logf = open("/tmp/fpv_tool_server.log", "ab")
     subprocess.Popen(
-        [SERVER_PYTHON, str(SERVER_SCRIPT), "--host", hostname, "--port", port],
+        [SERVER_PYTHON, str(SERVER_SCRIPT), "--host", hostname, "--port", port, "--out-dir", str(out_dir)],
         stdout=logf, stderr=logf, stdin=subprocess.DEVNULL, cwd=str(ROOT),
     )
     for _ in range(30):
-        if server_up(url):
+        if server_output_root(url):
             log("local server ready")
             return
         time.sleep(1)
@@ -137,10 +146,11 @@ def resolve_annotation(query: str) -> Path:
 
 
 def run_batch(annotations: list[Path], preset_flags: list[str], args: argparse.Namespace, space: str) -> int:
-    results_file = args.results_file or (ROOT / "scenes" / f".batch_{args.preset}.json")
+    results_file = args.results_file or (args.out_dir / "scenes" / f".batch_{args.preset}.json")
     cmd = [
         sys.executable, str(BATCH_SCRIPT),
         "--server", args.server,
+        "--out-dir", str(args.out_dir),
         "--annotations", *[str(a) for a in annotations],
         "--vggt-space", space,
         "--vggt-backend", "omega",
@@ -151,6 +161,11 @@ def run_batch(annotations: list[Path], preset_flags: list[str], args: argparse.N
         "--results-file", str(results_file),
         *preset_flags,
     ]
+    if args.use_pod:
+        # Each completed Omega request leaves a large Gradio upload directory
+        # behind. The batch is sequential, so cleaning here is safe and keeps a
+        # long run below the pod's workspace limit.
+        cmd.extend(["--omega-cleanup-every", "1"])
     if args.skip_existing:
         cmd.append("--skip-existing")
     log("running batch:\n  " + " ".join(cmd))
@@ -162,6 +177,7 @@ def main() -> int:
     parser.add_argument("scenes", nargs="+", help="annotation paths or scene name/date queries")
     parser.add_argument("--preset", choices=sorted(PRESETS), default="clean")
     parser.add_argument("--server", default=SERVER_URL)
+    parser.add_argument("--out-dir", type=Path, default=ROOT, help="shared scene output root for the server and batch")
     parser.add_argument("--pod-id", default=omega_pod.POD_ID)
     parser.add_argument("--stop-pod", action="store_true", help="stop the pod when the batch finishes")
     parser.add_argument("--skip-existing", action="store_true", help="skip scenes already reconstructed")
@@ -183,7 +199,7 @@ def main() -> int:
     if args.dry_run:
         return 0
 
-    ensure_local_server(args.server, args.start_server)
+    ensure_local_server(args.server, args.start_server, args.out_dir)
 
     if args.use_pod:
         space = omega_pod.up(args.pod_id, ready_timeout_s=args.ready_timeout)

--- a/tools/pipeline/run_vggt_batch_from_annotations.py
+++ b/tools/pipeline/run_vggt_batch_from_annotations.py
@@ -69,33 +69,46 @@ def select_attack_pause_chain(intervals: list[dict[str, Any]]) -> list[dict[str,
     return [intervals[index] for index in selected_indexes]
 
 
-def trim_to_tail_seconds(selected: list[dict[str, Any]], tail_seconds: float) -> list[dict[str, Any]]:
-    """Keep only the last `tail_seconds` of the concatenated flight sequence.
+def trim_to_tail_window(
+    selected: list[dict[str, Any]],
+    tail_seconds: float,
+    exclude_tail_seconds: float = 0.0,
+) -> list[dict[str, Any]]:
+    """Clip a concatenated flight sequence to ``[-tail-exclude, -exclude]``.
 
-    Walks back from the final (attack) segment; the earliest included segment is
-    shortened (start_s moved forward) so the total is exactly tail_seconds. Segment
-    structure/ids are preserved for whatever survives the window.
+    Segment IDs and source-video timestamps are preserved, including when the
+    requested window crosses a pause-linked segment boundary.
     """
-    if tail_seconds <= 0:
+    if not selected or (tail_seconds <= 0 and exclude_tail_seconds <= 0):
         return selected
     total = sum(float(s["duration_s"]) for s in selected)
-    if total <= tail_seconds:
-        return selected
-    remaining = tail_seconds
+    window_end = max(0.0, total - max(0.0, exclude_tail_seconds))
+    window_start = 0.0 if tail_seconds <= 0 else max(0.0, window_end - tail_seconds)
+    if window_end <= window_start:
+        return []
+
     out: list[dict[str, Any]] = []
-    for seg in reversed(selected):
+    sequence_start = 0.0
+    for seg in selected:
         dur = float(seg["duration_s"])
-        if dur <= remaining:
-            out.insert(0, seg)
-            remaining -= dur
-        else:
+        sequence_end = sequence_start + dur
+        overlap_start = max(sequence_start, window_start)
+        overlap_end = min(sequence_end, window_end)
+        if overlap_end > overlap_start:
             trimmed = dict(seg)
-            trimmed["start_s"] = round(float(seg["end_s"]) - remaining, 3)
-            trimmed["duration_s"] = round(remaining, 3)
-            out.insert(0, trimmed)
-            remaining = 0.0
-            break
+            source_start = float(seg["start_s"]) + (overlap_start - sequence_start)
+            source_end = float(seg["start_s"]) + (overlap_end - sequence_start)
+            trimmed["start_s"] = round(source_start, 3)
+            trimmed["end_s"] = round(source_end, 3)
+            trimmed["duration_s"] = round(source_end - source_start, 3)
+            out.append(trimmed)
+        sequence_start = sequence_end
     return out
+
+
+def trim_to_tail_seconds(selected: list[dict[str, Any]], tail_seconds: float) -> list[dict[str, Any]]:
+    """Backward-compatible tail trim with no excluded final interval."""
+    return trim_to_tail_window(selected, tail_seconds)
 
 
 def request_json(request: urllib.request.Request, *, retries: int, timeout: int) -> dict[str, Any]:
@@ -279,7 +292,10 @@ def run_batch(args: argparse.Namespace) -> int:
         if not selected:
             print(f"[{batch_index}/{len(paths)}] skip {path.name}: no flight intervals", flush=True)
             continue
-        selected = trim_to_tail_seconds(selected, args.tail_seconds)
+        selected = trim_to_tail_window(selected, args.tail_seconds, args.exclude_tail_seconds)
+        if not selected:
+            print(f"[{batch_index}/{len(paths)}] skip {path.name}: tail window is empty", flush=True)
+            continue
 
         total_s = sum(float(row["duration_s"]) for row in selected)
         body = request_body(annotation, selected, args)
@@ -353,6 +369,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--offset", type=int, default=0)
     parser.add_argument("--fps", type=float, default=10.0)
     parser.add_argument("--tail-seconds", type=float, default=0.0, help="keep only the last N seconds of the flight sequence (0 = whole chain)")
+    parser.add_argument(
+        "--exclude-tail-seconds",
+        type=float,
+        default=0.0,
+        help="exclude the final N seconds before applying --tail-seconds",
+    )
     parser.add_argument("--no-masks", action="store_true", help="ignore the annotation's exclusion_masks (no black boxes, no mask_black_bg)")
     parser.add_argument("--client-sky-seg", action="store_true", help="run skyseg on CLEAN frames client-side, then paint sky (and boxes) black (sky_then_boxes)")
     parser.add_argument("--width", type=int, default=660)
@@ -400,6 +422,8 @@ def parse_args() -> argparse.Namespace:
     args = parser.parse_args()
     if args.omega_cleanup_every < 0:
         parser.error("--omega-cleanup-every must be zero or greater")
+    if args.tail_seconds < 0 or args.exclude_tail_seconds < 0:
+        parser.error("tail durations must be zero or greater")
     if not args.results_file.is_absolute():
         args.results_file = args.out_dir / args.results_file
     return args

--- a/tools/pipeline/run_vggt_batch_from_annotations.py
+++ b/tools/pipeline/run_vggt_batch_from_annotations.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import subprocess
+import sys
 import time
 import urllib.error
 import urllib.parse
@@ -96,7 +98,33 @@ def trim_to_tail_seconds(selected: list[dict[str, Any]], tail_seconds: float) ->
     return out
 
 
-def post_json(base_url: str, path: str, body: dict[str, Any]) -> dict[str, Any]:
+def request_json(request: urllib.request.Request, *, retries: int, timeout: int) -> dict[str, Any]:
+    """Retry only transient local-server failures.
+
+    A reconstruction request is idempotent by scene id while it is active, so a
+    retry after a dropped response returns the same job instead of starting a
+    duplicate job.
+    """
+    last_error: Exception | None = None
+    for attempt in range(retries + 1):
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            # The server can briefly return 5xx while it is creating its job
+            # directory. Do not retry client errors because they are input bugs.
+            if exc.code < 500:
+                raise
+            last_error = exc
+        except urllib.error.URLError as exc:
+            last_error = exc
+        if attempt < retries:
+            time.sleep(min(10, 2**attempt))
+    assert last_error is not None
+    raise last_error
+
+
+def post_json(base_url: str, path: str, body: dict[str, Any], *, retries: int) -> dict[str, Any]:
     data = json.dumps(body).encode("utf-8")
     request = urllib.request.Request(
         urllib.parse.urljoin(base_url, path),
@@ -104,13 +132,12 @@ def post_json(base_url: str, path: str, body: dict[str, Any]) -> dict[str, Any]:
         headers={"Content-Type": "application/json"},
         method="POST",
     )
-    with urllib.request.urlopen(request, timeout=60) as response:
-        return json.loads(response.read().decode("utf-8"))
+    return request_json(request, retries=retries, timeout=60)
 
 
-def get_json(base_url: str, path: str) -> dict[str, Any]:
-    with urllib.request.urlopen(urllib.parse.urljoin(base_url, path), timeout=60) as response:
-        return json.loads(response.read().decode("utf-8"))
+def get_json(base_url: str, path: str, *, retries: int) -> dict[str, Any]:
+    request = urllib.request.Request(urllib.parse.urljoin(base_url, path), method="GET")
+    return request_json(request, retries=retries, timeout=60)
 
 
 def request_body(annotation: dict[str, Any], selected: list[dict[str, Any]], args: argparse.Namespace) -> dict[str, Any]:
@@ -162,8 +189,8 @@ def request_body(annotation: dict[str, Any], selected: list[dict[str, Any]], arg
     }
 
 
-def scene_dir_for(annotation: dict[str, Any], scene_id: str) -> Path:
-    return ROOT / "scenes" / slugify(annotation["video_file"]) / scene_id
+def scene_dir_for(out_dir: Path, annotation: dict[str, Any], scene_id: str) -> Path:
+    return out_dir / "scenes" / slugify(annotation["video_file"]) / scene_id
 
 
 def scene_is_complete(scene_dir: Path) -> bool:
@@ -174,8 +201,8 @@ def scene_is_complete(scene_dir: Path) -> bool:
     )
 
 
-def result_from_scene(path: Path, annotation: dict[str, Any], scene_id: str, selected: list[dict[str, Any]], status: str) -> dict[str, Any]:
-    scene_dir = scene_dir_for(annotation, scene_id)
+def result_from_scene(out_dir: Path, path: Path, annotation: dict[str, Any], scene_id: str, selected: list[dict[str, Any]], status: str) -> dict[str, Any]:
+    scene_dir = scene_dir_for(out_dir, annotation, scene_id)
     manifest_path = scene_dir / "scene_manifest.json"
     manifest: dict[str, Any] = {}
     if manifest_path.exists():
@@ -194,6 +221,42 @@ def result_from_scene(path: Path, annotation: dict[str, Any], scene_id: str, sel
     }
 
 
+def load_results(path: Path) -> dict[str, dict[str, Any]]:
+    try:
+        rows = json.loads(path.read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return {}
+    if not isinstance(rows, list):
+        return {}
+    return {str(row.get("scene_id")): row for row in rows if isinstance(row, dict) and row.get("scene_id")}
+
+
+def write_results(path: Path, results: dict[str, dict[str, Any]]) -> None:
+    """Write a durable checkpoint after every resolved scene."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(list(results.values()), indent=2))
+    tmp.replace(path)
+
+
+def cleanup_omega_uploads(args: argparse.Namespace) -> bool:
+    """Remove completed Gradio upload directories between sequential jobs."""
+    cmd = [sys.executable, str(ROOT / "tools" / "pipeline" / "omega_pod.py"), "cleanup", "--ready-timeout", "60"]
+    result = subprocess.run(cmd, text=True, capture_output=True)
+    if result.returncode:
+        print(
+            "[batch] warning: Omega upload-cache cleanup failed; continuing with the durable checkpoint intact: "
+            + (result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"),
+            file=sys.stderr,
+            flush=True,
+        )
+        return False
+    if not args.quiet:
+        output = result.stdout.strip()
+        print(f"[batch] Omega upload cache cleared{': ' + output if output else ''}", flush=True)
+    return True
+
+
 def run_batch(args: argparse.Namespace) -> int:
     if args.annotations:
         paths = [Path(p) for p in args.annotations]
@@ -203,7 +266,8 @@ def run_batch(args: argparse.Namespace) -> int:
         raise SystemExit("No annotation files selected")
 
     print(f"[batch] selected {len(paths)} annotation file(s)", flush=True)
-    results: list[dict[str, Any]] = []
+    results = {} if args.reset_results else load_results(args.results_file)
+    resolved_jobs = 0
     for batch_index, path in enumerate(paths, start=1):
         annotation = json.loads(path.read_text())
         if args.manual_only and annotation.get("auto_generated"):
@@ -221,13 +285,14 @@ def run_batch(args: argparse.Namespace) -> int:
         body = request_body(annotation, selected, args)
         segment_ids = ",".join(row["segment_id"] for row in selected)
         scene_id = f"{slugify(annotation['video_file'])}_{'_'.join(row['segment_id'] for row in selected)}"
-        if args.skip_existing and scene_is_complete(scene_dir_for(annotation, scene_id)):
+        if args.skip_existing and scene_is_complete(scene_dir_for(args.out_dir, annotation, scene_id)):
             if not args.quiet:
                 print(f"[{batch_index}/{len(paths)}] skip complete {scene_id}", flush=True)
-            results.append(result_from_scene(path, annotation, scene_id, selected, "skipped_complete"))
+            results[scene_id] = result_from_scene(args.out_dir, path, annotation, scene_id, selected, "skipped_complete")
+            write_results(args.results_file, results)
             continue
         print(f"[{batch_index}/{len(paths)}] {annotation['video_file']} -> {segment_ids} ({total_s:.3f}s @ {args.fps:g}fps)", flush=True)
-        response = post_json(args.server, "/api/reconstruct", body)
+        response = post_json(args.server, "/api/reconstruct", body, retries=args.server_retries)
         job_id = response["job_id"]
         scene_id = response["scene_id"]
         if not args.quiet:
@@ -235,7 +300,7 @@ def run_batch(args: argparse.Namespace) -> int:
 
         last_line = ""
         while True:
-            job = get_json(args.server, f"/api/jobs/{job_id}")
+            job = get_json(args.server, f"/api/jobs/{job_id}", retries=args.server_retries)
             logs = job.get("logs") or []
             line = f"[poll] {scene_id}: {job.get('status')} | {job.get('step')}"
             if logs:
@@ -245,12 +310,11 @@ def run_batch(args: argparse.Namespace) -> int:
                     print(line, flush=True)
                 last_line = line
             if job.get("status") in {"done", "error"}:
-                scene_manifest = ROOT / "scenes" / slugify(annotation["video_file"]) / scene_id / "scene_manifest.json"
+                scene_manifest = scene_dir_for(args.out_dir, annotation, scene_id) / "scene_manifest.json"
                 model_config: dict[str, Any] = {}
                 if scene_manifest.exists():
                     model_config = json.loads(scene_manifest.read_text()).get("model_config", {})
-                results.append(
-                    {
+                results[scene_id] = {
                         "annotation": str(path),
                         "video_file": annotation["video_file"],
                         "scene_id": scene_id,
@@ -261,27 +325,29 @@ def run_batch(args: argparse.Namespace) -> int:
                         "viewer_url": job.get("viewer_url", ""),
                         "segments": [row["segment_id"] for row in selected],
                         "model_config": model_config,
-                    }
-                )
+                }
+                write_results(args.results_file, results)
+                resolved_jobs += 1
+                if args.omega_cleanup_every and resolved_jobs % args.omega_cleanup_every == 0:
+                    cleanup_omega_uploads(args)
                 print(f"[{batch_index}/{len(paths)}] {scene_id}: {job.get('status')}", flush=True)
                 if job.get("status") == "error" and not args.continue_on_error:
                     print(f"[batch] stopping after error in {scene_id}", flush=True)
-                    args.results_file.write_text(json.dumps(results, indent=2))
                     return 1
                 break
             time.sleep(args.poll_seconds)
 
-    out_path = args.results_file
-    out_path.write_text(json.dumps(results, indent=2))
-    done = sum(1 for row in results if row["status"] == "done")
-    errors = sum(1 for row in results if row["status"] == "error")
-    print(f"[batch] complete: {done} done, {errors} error(s); wrote {out_path}", flush=True)
+    write_results(args.results_file, results)
+    done = sum(1 for row in results.values() if row["status"] == "done")
+    errors = sum(1 for row in results.values() if row["status"] == "error")
+    print(f"[batch] complete: {done} done, {errors} error(s); wrote {args.results_file}", flush=True)
     return 0 if errors == 0 else 1
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--server", default="http://127.0.0.1:8766")
+    parser.add_argument("--out-dir", type=Path, default=ROOT, help="scene output root configured on the FPV tool server")
     parser.add_argument("--annotations", nargs="*", help="explicit annotation JSON paths (overrides glob/offset/limit)")
     parser.add_argument("--limit", type=int, default=10)
     parser.add_argument("--offset", type=int, default=0)
@@ -310,6 +376,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--adaptive-tail-dense-s", type=float, default=0.0,
                         help="additionally keep every sampled frame in the last N seconds of flight (on top of --adaptive-target)")
     parser.add_argument("--poll-seconds", type=float, default=5.0)
+    parser.add_argument("--server-retries", type=int, default=3, help="retry transient local-server failures this many times")
+    parser.add_argument(
+        "--omega-cleanup-every",
+        type=int,
+        default=0,
+        help="clear completed Omega Gradio uploads every N resolved jobs (0 disables)",
+    )
     parser.add_argument("--skip-camera-views", action="store_true")
     parser.add_argument("--no-refresh-vggt", action="store_true")
     parser.add_argument("--continue-on-error", action="store_true")
@@ -317,10 +390,18 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--manual-only", action="store_true",
                         help="skip annotations flagged auto_generated (process only hand-tagged videos)")
     parser.add_argument("--quiet", action="store_true")
-    parser.add_argument("--results-file", type=Path, default=ROOT / "scenes" / ".batch_results.json")
+    parser.add_argument(
+        "--results-file",
+        type=Path,
+        default=Path("scenes/.batch_results.json"),
+        help="checkpoint ledger, relative to --out-dir unless absolute",
+    )
+    parser.add_argument("--reset-results", action="store_true", help="discard prior checkpoints in --results-file")
     args = parser.parse_args()
+    if args.omega_cleanup_every < 0:
+        parser.error("--omega-cleanup-every must be zero or greater")
     if not args.results_file.is_absolute():
-        args.results_file = ROOT / args.results_file
+        args.results_file = args.out_dir / args.results_file
     return args
 
 

--- a/tools/pipeline/run_vggt_batch_from_annotations.py
+++ b/tools/pipeline/run_vggt_batch_from_annotations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -170,7 +171,7 @@ def request_body(annotation: dict[str, Any], selected: list[dict[str, Any]], arg
         ],
         "segments": selected,
         "sample_fps": args.fps,
-        "target_frames": 0,
+        "target_frames": args.adaptive_target if args.adaptive_fps else 0,
         "default_scale_m_per_unit": args.scale,
         "crop_preset": args.crop_preset,
         "width": args.width,
@@ -186,6 +187,7 @@ def request_body(annotation: dict[str, Any], selected: list[dict[str, Any]], arg
         "vggt_conf_thres": args.vggt_conf_thres,
         "vggt_max_points_k": args.vggt_max_points_k,
         "vggt_mask_sky": args.vggt_mask_sky,
+        "omega_pod_id": args.omega_pod_id,
         "clahe": {"enabled": True, "clip_limit": args.clahe_clip} if args.clahe else None,
         "adaptive_fps": (
             {
@@ -231,6 +233,7 @@ def result_from_scene(out_dir: Path, path: Path, annotation: dict[str, Any], sce
         "viewer_url": manifest.get("viewer_url", f"/scenes/{slugify(annotation['video_file'])}/{scene_id}/viewer/index.html"),
         "segments": [row["segment_id"] for row in selected],
         "model_config": manifest.get("model_config", {}),
+        "quality": manifest.get("quality"),
     }
 
 
@@ -386,10 +389,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--vggt-timeout", type=int, default=1800)
     parser.add_argument("--vggt-space", default="")
     parser.add_argument("--vggt-backend", choices=["omega", "classic"], default="omega")
-    parser.add_argument("--vggt-upload-mode", choices=["auto", "images", "video"], default="video")
+    parser.add_argument("--vggt-upload-mode", choices=["auto", "images", "video"], default="images")
     parser.add_argument("--vggt-conf-thres", type=float, default=50.0)
     parser.add_argument("--vggt-max-points-k", type=float, default=1000.0)
     parser.add_argument("--vggt-mask-sky", action="store_true")
+    parser.add_argument("--omega-pod-id", default=os.environ.get("RUNPOD_POD_ID", "7i0jtqk99phk2j"))
     parser.add_argument("--clahe", action="store_true", help="sequence-uniform CLAHE contrast enhancement (for dark clips)")
     parser.add_argument("--clahe-clip", type=float, default=2.0, help="CLAHE contrast-limit (higher = stronger)")
     parser.add_argument("--adaptive-fps", action="store_true", help="motion-aware keyframing (more frames where motion is high, sharpest-in-window)")

--- a/tools/pipeline/test_run_vggt_batch.py
+++ b/tools/pipeline/test_run_vggt_batch.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Focused regression tests for the resumable VGGT batch runner."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).with_name("run_vggt_batch_from_annotations.py")
+SPEC = importlib.util.spec_from_file_location("run_vggt_batch", SCRIPT)
+assert SPEC and SPEC.loader
+batch = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(batch)
+
+
+class BatchRunnerTests(unittest.TestCase):
+    def test_checkpoint_replaces_previous_result_for_same_scene(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "scenes" / ".batch.json"
+            batch.write_results(path, {"scene-a": {"scene_id": "scene-a", "status": "error"}})
+            rows = batch.load_results(path)
+            rows["scene-a"] = {"scene_id": "scene-a", "status": "done"}
+            rows["scene-b"] = {"scene_id": "scene-b", "status": "skipped_complete"}
+            batch.write_results(path, rows)
+            saved = {row["scene_id"]: row["status"] for row in json.loads(path.read_text())}
+        self.assertEqual(saved, {"scene-a": "done", "scene-b": "skipped_complete"})
+
+    def test_scene_paths_follow_configured_output_root(self) -> None:
+        annotation = {"video_file": "2026-05-26_anti_drone_platform_biranit.mp4"}
+        self.assertEqual(
+            batch.scene_dir_for(Path("/tmp/output"), annotation, "scene-1"),
+            Path("/tmp/output/scenes/2026-05-26_anti_drone_platform_biranit/scene-1"),
+        )
+
+    def test_relative_result_file_uses_output_root(self) -> None:
+        with patch("sys.argv", ["batch", "--out-dir", "/tmp/output"]):
+            args = batch.parse_args()
+        self.assertEqual(args.results_file, Path("/tmp/output/scenes/.batch_results.json"))
+
+    def test_retries_transient_server_failure(self) -> None:
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return b'{"ok": true}'
+
+        request = batch.urllib.request.Request("http://127.0.0.1:8766/api/health")
+        with patch.object(batch.urllib.request, "urlopen", side_effect=[batch.urllib.error.URLError("offline"), Response()]) as open_mock:
+            with patch.object(batch.time, "sleep"):
+                self.assertEqual(batch.request_json(request, retries=1, timeout=1), {"ok": True})
+        self.assertEqual(open_mock.call_count, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/pipeline/test_run_vggt_batch.py
+++ b/tools/pipeline/test_run_vggt_batch.py
@@ -18,6 +18,33 @@ SPEC.loader.exec_module(batch)
 
 
 class BatchRunnerTests(unittest.TestCase):
+    def test_tail_window_excludes_final_second(self) -> None:
+        selected = [{"segment_id": "seg01", "start_s": 10.0, "end_s": 30.0, "duration_s": 20.0}]
+        self.assertEqual(
+            batch.trim_to_tail_window(selected, tail_seconds=12, exclude_tail_seconds=1),
+            [{"segment_id": "seg01", "start_s": 17.0, "end_s": 29.0, "duration_s": 12.0}],
+        )
+
+    def test_tail_window_crosses_concatenated_segments(self) -> None:
+        selected = [
+            {"segment_id": "seg01", "start_s": 0.0, "end_s": 5.0, "duration_s": 5.0},
+            {"segment_id": "seg02", "start_s": 10.0, "end_s": 20.0, "duration_s": 10.0},
+        ]
+        self.assertEqual(
+            batch.trim_to_tail_window(selected, tail_seconds=12, exclude_tail_seconds=1),
+            [
+                {"segment_id": "seg01", "start_s": 2.0, "end_s": 5.0, "duration_s": 3.0},
+                {"segment_id": "seg02", "start_s": 10.0, "end_s": 19.0, "duration_s": 9.0},
+            ],
+        )
+
+    def test_tail_window_is_empty_when_sequence_is_inside_excluded_tail(self) -> None:
+        selected = [{"segment_id": "seg01", "start_s": 2.0, "end_s": 2.5, "duration_s": 0.5}]
+        self.assertEqual(
+            batch.trim_to_tail_window(selected, tail_seconds=12, exclude_tail_seconds=1),
+            [],
+        )
+
     def test_checkpoint_replaces_previous_result_for_same_scene(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "scenes" / ".batch.json"

--- a/tools/pipeline/test_scene_pipeline_config.py
+++ b/tools/pipeline/test_scene_pipeline_config.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Focused tests for reconstruction experiment settings and scene metadata."""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sys.path.insert(0, str(ROOT / "tools" / "pipeline"))
+server = load_module("fpv_tool_server_test", ROOT / "tools" / "server" / "fpv_tool_server.py")
+reconstruct = load_module("reconstruct_scenes_test", ROOT / "tools" / "pipeline" / "reconstruct_scenes.py")
+
+
+class ScenePipelineConfigTests(unittest.TestCase):
+    def test_clean_crop_is_explicit_260_by_280(self) -> None:
+        crop = server.crop_config("central_clean")
+        self.assertEqual(crop["reference_bbox_px"], {"x": 320, "y": 190, "width": 260, "height": 280})
+        self.assertIn("iw*260/848", server.ffmpeg_filter("central_clean", 260, 24))
+        self.assertIn("iw*320/848", server.ffmpeg_filter("central_clean", 260, 24))
+
+    def test_direct_images_are_the_default_transport(self) -> None:
+        state = SimpleNamespace(
+            vggt_space="facebook/vggt-omega",
+            vggt_backend="omega",
+            default_scale=117.6,
+        )
+        config = server.reconstruction_config(state, {})
+        self.assertEqual(config["vggt"]["upload_mode"], "images")
+        self.assertIsNone(config["vggt"]["upload_video_fps"])
+
+    def test_experiment_overrides_follow_preset_defaults(self) -> None:
+        args = argparse.Namespace(preset="clean", tail_seconds=8.0, exclude_tail_seconds=2.0, frames=80)
+        flags = reconstruct.reconstruction_flags(args)
+        self.assertEqual(flags[flags.index("--tail-seconds") + 1], "8.0")
+        self.assertEqual(flags[flags.index("--exclude-tail-seconds") + 1], "2.0")
+        self.assertEqual(flags[flags.index("--adaptive-target") + 1], "80")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/publishing/build_web_data.mjs
+++ b/tools/publishing/build_web_data.mjs
@@ -58,27 +58,10 @@ function readAnnotations() {
 // reconstruction only; density variants (scene dirs suffixed "__3m"/"__5m"/...)
 // exist for the local scene-viewer tool and are excluded here.
 function buildSceneIndex() {
-  const scenesDir = path.join(repoRoot, "scenes");
   const index = new Map();
   for (const [videoId, scenes] of readSceneManifests(repoRoot)) {
     const scene = [...scenes].sort((a, b) => a.scene_id.localeCompare(b.scene_id))[0];
     if (scene) index.set(videoId, { path: scene.path, quality: scene.quality ?? null });
-  }
-  if (!fs.existsSync(scenesDir)) return index;
-  for (const stem of fs.readdirSync(scenesDir, { withFileTypes: true })) {
-    if (!stem.isDirectory()) continue;
-    const base = path.join(scenesDir, stem.name);
-    for (const scene of fs.readdirSync(base, { withFileTypes: true }).sort((a, b) =>
-      a.name.localeCompare(b.name),
-    )) {
-      if (!scene.isDirectory() || scene.name.includes("__")) continue; // skip variants
-      const metaPath = path.join(base, scene.name, "viewer", "scene_meta.json");
-      if (fs.existsSync(metaPath)) {
-        const meta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
-        index.set(stem.name, { path: `${stem.name}/${scene.name}`, quality: meta.quality ?? null });
-        break;
-      }
-    }
   }
   return index;
 }

--- a/tools/publishing/build_web_data.mjs
+++ b/tools/publishing/build_web_data.mjs
@@ -62,7 +62,7 @@ function buildSceneIndex() {
   const index = new Map();
   for (const [videoId, scenes] of readSceneManifests(repoRoot)) {
     const scene = [...scenes].sort((a, b) => a.scene_id.localeCompare(b.scene_id))[0];
-    if (scene) index.set(videoId, scene.path);
+    if (scene) index.set(videoId, { path: scene.path, quality: scene.quality ?? null });
   }
   if (!fs.existsSync(scenesDir)) return index;
   for (const stem of fs.readdirSync(scenesDir, { withFileTypes: true })) {
@@ -72,8 +72,10 @@ function buildSceneIndex() {
       a.name.localeCompare(b.name),
     )) {
       if (!scene.isDirectory() || scene.name.includes("__")) continue; // skip variants
-      if (fs.existsSync(path.join(base, scene.name, "viewer", "scene_meta.json"))) {
-        index.set(stem.name, `${stem.name}/${scene.name}`);
+      const metaPath = path.join(base, scene.name, "viewer", "scene_meta.json");
+      if (fs.existsSync(metaPath)) {
+        const meta = JSON.parse(fs.readFileSync(metaPath, "utf8"));
+        index.set(stem.name, { path: `${stem.name}/${scene.name}`, quality: meta.quality ?? null });
         break;
       }
     }
@@ -124,7 +126,8 @@ for (const raw of readCatalogVideos()) {
   const previousVideoFile = previousVideoFiles.get(videoFile);
   const existing = existingVideos.get(videoFile) ?? (previousVideoFile ? existingVideos.get(previousVideoFile) : undefined);
   const existingScenePath = existing?.scenePath?.replaceAll("barashit", "biranit") ?? null;
-  const scenePath = sceneIndex.get(slug) ?? existingScenePath;
+  const scene = sceneIndex.get(slug);
+  const scenePath = scene?.path ?? existingScenePath;
   videos.push({
     videoFile,
     slug,
@@ -136,6 +139,7 @@ for (const raw of readCatalogVideos()) {
     thumbWidths: thumb?.widths ?? existing?.thumbWidths ?? null,
     blur: thumb?.blurDataURL ?? existing?.blur ?? null,
     scenePath,
+    sceneQuality: scene?.quality ?? existing?.sceneQuality ?? null,
     segments: ann?.segments ?? null,
     annotationAuto: ann ? Boolean(ann.auto_generated) : null,
   });

--- a/tools/publishing/gzip_scene_bins.py
+++ b/tools/publishing/gzip_scene_bins.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Migrate existing S3 scene binaries to transparent gzip encoding.
+
+The command is resumable: objects already carrying ``Content-Encoding: gzip``
+are skipped. Each remaining object is downloaded, deterministically compressed,
+uploaded atomically to the same key with corrected metadata, and verified.
+"""
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import gzip
+import json
+import os
+import subprocess
+import tempfile
+import threading
+from pathlib import Path
+from typing import Any
+
+
+PRINT_LOCK = threading.Lock()
+
+
+def aws_command(profile: str, *args: str) -> list[str]:
+    command = ["aws", *args]
+    if profile:
+        command.extend(["--profile", profile])
+    return command
+
+
+def run_aws(profile: str, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        aws_command(profile, *args),
+        check=True,
+        capture_output=True,
+        text=True,
+        env={**os.environ, "AWS_PAGER": ""},
+    )
+
+
+def json_aws(profile: str, *args: str) -> Any:
+    result = run_aws(profile, *args, "--output", "json")
+    return json.loads(result.stdout or "null")
+
+
+def is_scene_binary(key: str) -> bool:
+    return key.startswith("scenes/") and "/viewer/" in key and key.endswith(".bin")
+
+
+def list_scene_binaries(bucket: str, prefix: str, profile: str) -> list[dict[str, Any]]:
+    payload = json_aws(profile, "s3api", "list-objects-v2", "--bucket", bucket, "--prefix", prefix)
+    return [row for row in payload.get("Contents", []) if is_scene_binary(str(row.get("Key", "")))]
+
+
+def head_object(bucket: str, key: str, profile: str) -> dict[str, Any]:
+    return json_aws(profile, "s3api", "head-object", "--bucket", bucket, "--key", key)
+
+
+def gzip_file(source: Path, target: Path) -> None:
+    with source.open("rb") as src, target.open("wb") as raw_out:
+        with gzip.GzipFile(filename="", mode="wb", fileobj=raw_out, compresslevel=9, mtime=0) as dst:
+            while chunk := src.read(1024 * 1024):
+                dst.write(chunk)
+
+
+def migrate_object(
+    row: dict[str, Any],
+    *,
+    bucket: str,
+    profile: str,
+    force: bool,
+) -> dict[str, Any]:
+    key = str(row["Key"])
+    before = head_object(bucket, key, profile)
+    encoding = str(before.get("ContentEncoding") or "").lower()
+    if "gzip" in {part.strip() for part in encoding.split(",")} and not force:
+        return {"key": key, "status": "skipped", "compressed_bytes": int(before.get("ContentLength", 0))}
+
+    with tempfile.TemporaryDirectory(prefix="fpv-scene-gzip-") as tmp:
+        raw_path = Path(tmp) / "scene.bin"
+        gzip_path = Path(tmp) / "scene.bin.gz"
+        run_aws(
+            profile,
+            "s3",
+            "cp",
+            f"s3://{bucket}/{key}",
+            str(raw_path),
+            "--only-show-errors",
+        )
+        gzip_file(raw_path, gzip_path)
+        run_aws(
+            profile,
+            "s3",
+            "cp",
+            str(gzip_path),
+            f"s3://{bucket}/{key}",
+            "--only-show-errors",
+            "--content-type",
+            "application/octet-stream",
+            "--content-encoding",
+            "gzip",
+            "--cache-control",
+            "public,max-age=31536000",
+        )
+        after = head_object(bucket, key, profile)
+        if str(after.get("ContentEncoding") or "").lower() != "gzip":
+            raise RuntimeError(f"{key}: uploaded object is missing Content-Encoding: gzip")
+        if int(after.get("ContentLength", -1)) != gzip_path.stat().st_size:
+            raise RuntimeError(f"{key}: uploaded compressed size does not match local result")
+        return {
+            "key": key,
+            "status": "migrated",
+            "raw_bytes": raw_path.stat().st_size,
+            "compressed_bytes": gzip_path.stat().st_size,
+        }
+
+
+def invalidate(distribution_id: str, profile: str) -> str:
+    payload = json_aws(
+        profile,
+        "cloudfront",
+        "create-invalidation",
+        "--distribution-id",
+        distribution_id,
+        "--paths",
+        "/scenes/*",
+    )
+    return str(payload["Invalidation"]["Id"])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--bucket", default=os.environ.get("FPV_BUCKET_NAME", "fpv-drone-strikes-lebanon-dataset"))
+    parser.add_argument("--prefix", default="scenes/")
+    parser.add_argument("--profile", default=os.environ.get("AWS_PROFILE", "admin"))
+    parser.add_argument("--workers", type=int, default=6)
+    parser.add_argument("--limit", type=int)
+    parser.add_argument("--force", action="store_true", help="recompress objects that already have gzip metadata")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--invalidate-distribution")
+    args = parser.parse_args()
+    if args.workers < 1:
+        parser.error("--workers must be at least 1")
+
+    objects = list_scene_binaries(args.bucket, args.prefix, args.profile)
+    if args.limit:
+        objects = objects[: args.limit]
+    print(f"[gzip-scenes] found {len(objects)} scene binaries", flush=True)
+    if args.dry_run:
+        for row in objects:
+            print(row["Key"])
+        return 0
+
+    results: list[dict[str, Any]] = []
+    errors: list[str] = []
+    completed = 0
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futures = {
+            pool.submit(
+                migrate_object,
+                row,
+                bucket=args.bucket,
+                profile=args.profile,
+                force=args.force,
+            ): str(row["Key"])
+            for row in objects
+        }
+        for future in concurrent.futures.as_completed(futures):
+            completed += 1
+            key = futures[future]
+            try:
+                result = future.result()
+                results.append(result)
+                with PRINT_LOCK:
+                    print(f"[gzip-scenes {completed}/{len(objects)}] {result['status']} {key}", flush=True)
+            except Exception as exc:
+                errors.append(f"{key}: {exc}")
+                with PRINT_LOCK:
+                    print(f"[gzip-scenes {completed}/{len(objects)}] ERROR {key}: {exc}", flush=True)
+
+    migrated = [row for row in results if row["status"] == "migrated"]
+    raw_bytes = sum(int(row.get("raw_bytes", 0)) for row in migrated)
+    compressed_bytes = sum(int(row.get("compressed_bytes", 0)) for row in migrated)
+    print(
+        f"[gzip-scenes] migrated={len(migrated)} skipped={len(results) - len(migrated)} "
+        f"errors={len(errors)} raw_bytes={raw_bytes} compressed_bytes={compressed_bytes}",
+        flush=True,
+    )
+    if errors:
+        for error in errors:
+            print(f"[gzip-scenes] {error}", flush=True)
+        return 1
+    if migrated and args.invalidate_distribution:
+        invalidation_id = invalidate(args.invalidate_distribution, args.profile)
+        print(f"[gzip-scenes] invalidation={invalidation_id} path=/scenes/*", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/publishing/publish_web.sh
+++ b/tools/publishing/publish_web.sh
@@ -38,7 +38,10 @@ aws s3 sync build/thumbnails/ "$BUCKET/thumbnails/" \
   --cache-control "public,max-age=31536000,immutable"
 
 if [ "$SKIP_SCENES" = "0" ]; then
-  echo "== 4/5 upload scene viewer data (incremental, base only) =="
+  echo "== 4/5 upload gzip-compressed scene viewer data (incremental, base only) =="
+  GZIP_SCENES_DIR="build/web/gzip-scenes"
+  rm -rf "$GZIP_SCENES_DIR"
+  mkdir -p "$GZIP_SCENES_DIR"
   for d in scenes/*/*/viewer; do
     [ -f "$d/scene_meta.json" ] || continue
     # Production ships base reconstructions only; skip density variants.
@@ -47,9 +50,18 @@ if [ "$SKIP_SCENES" = "0" ]; then
     aws s3 sync "$d/" "$BUCKET/$d/" \
       --exclude "*" --include "scene_meta.json" \
       --content-type application/json --cache-control "public,max-age=300"
-    aws s3 sync "$d/" "$BUCKET/$d/" \
+    gzip_dir="$GZIP_SCENES_DIR/${d#scenes/}"
+    mkdir -p "$gzip_dir"
+    for source in "$d"/*.bin; do
+      [ -f "$source" ] || continue
+      target="$gzip_dir/$(basename "$source")"
+      gzip -9 -n -c "$source" > "$target"
+      touch -r "$source" "$target"
+    done
+    aws s3 sync "$gzip_dir/" "$BUCKET/$d/" \
       --exclude "*" --include "*.bin" \
       --content-type application/octet-stream \
+      --content-encoding gzip \
       --cache-control "public,max-age=31536000"
     [ -d "$d/camera_view_assets" ] && aws s3 sync "$d/camera_view_assets/" \
       "$BUCKET/$d/camera_view_assets/" \

--- a/tools/publishing/test_gzip_scene_bins.py
+++ b/tools/publishing/test_gzip_scene_bins.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import gzip
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("gzip_scene_bins.py")
+SPEC = importlib.util.spec_from_file_location("gzip_scene_bins", SCRIPT)
+assert SPEC and SPEC.loader
+gzip_scene_bins = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(gzip_scene_bins)
+
+
+class GzipSceneBinsTests(unittest.TestCase):
+    def test_scene_binary_filter(self) -> None:
+        self.assertTrue(gzip_scene_bins.is_scene_binary("scenes/video/scene/viewer/points_positions.bin"))
+        self.assertFalse(gzip_scene_bins.is_scene_binary("scenes/video/scene/point_cloud.npz"))
+        self.assertFalse(gzip_scene_bins.is_scene_binary("other/viewer/points_positions.bin"))
+
+    def test_gzip_is_deterministic_and_decodes_exactly(self) -> None:
+        payload = (b"point-cloud-data\x00" * 1000) + bytes(range(256))
+        with tempfile.TemporaryDirectory() as tmp:
+            source = Path(tmp) / "source.bin"
+            first = Path(tmp) / "first.gz"
+            second = Path(tmp) / "second.gz"
+            source.write_bytes(payload)
+            gzip_scene_bins.gzip_file(source, first)
+            gzip_scene_bins.gzip_file(source, second)
+            self.assertEqual(first.read_bytes(), second.read_bytes())
+            self.assertEqual(gzip.decompress(first.read_bytes()), payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/server/fpv_tool_server.py
+++ b/tools/server/fpv_tool_server.py
@@ -40,6 +40,10 @@ SCENE_VIEWER_INDEX_RE = re.compile(r"^/scenes/(.+)/viewer(?:/index\.html)?/?$")
 # Soft advisory only: above this many frames VGGT reconstruction gets slow/heavy.
 # This is NOT a hard cap -- frames are capped only when max_vggt_frames > 0.
 VGGT_FRAME_WARN_THRESHOLD = 125
+CENTRAL_CLEAN_REFERENCE_SIZE = (848, 478)
+# Preserve the horizontal centre of the previously validated clean crop while
+# narrowing the actual model input to the requested 260x280 region.
+CENTRAL_CLEAN_REFERENCE_BBOX = (320, 190, 260, 280)
 
 # Local copy of the VGGT-Omega sky-segmentation model, used to run skyseg on the
 # CLEAN frames client-side (before painting exclusion boxes), so the black boxes
@@ -120,15 +124,17 @@ def body_bool(body: dict[str, object], key: str, default: bool = False) -> bool:
 
 def crop_config(crop_preset: str) -> dict[str, object]:
     if crop_preset == "central_clean":
+        ref_w, ref_h = CENTRAL_CLEAN_REFERENCE_SIZE
+        x, y, width, height = CENTRAL_CLEAN_REFERENCE_BBOX
         return {
             "preset": crop_preset,
-            "reference_size_px": {"width": 848, "height": 478},
-            "reference_bbox_px": {"x": 120, "y": 190, "width": 660, "height": 280},
+            "reference_size_px": {"width": ref_w, "height": ref_h},
+            "reference_bbox_px": {"x": x, "y": y, "width": width, "height": height},
             "ffmpeg_crop_expr": (
-                "crop=trunc(iw*660/848/2)*2:"
-                "trunc(ih*280/478/2)*2:"
-                "trunc(iw*120/848/2)*2:"
-                "trunc(ih*190/478/2)*2"
+                f"crop=trunc(iw*{width}/{ref_w}/2)*2:"
+                f"trunc(ih*{height}/{ref_h}/2)*2:"
+                f"trunc(iw*{x}/{ref_w}/2)*2:"
+                f"trunc(ih*{y}/{ref_h}/2)*2"
             ),
         }
     return {"preset": crop_preset}
@@ -148,10 +154,14 @@ def reconstruction_config(
 ) -> dict[str, object]:
     sample_fps = float(body.get("sample_fps", 0) or 0)
     max_vggt_frames = int(body.get("max_vggt_frames", 0) or 0)
-    upload_video_fps = min(float(effective_sample_fps or sample_fps or 2.0), 2.0)
     vggt_space = str(body.get("vggt_space") or state.vggt_space)
     vggt_backend = str(body.get("vggt_backend") or state.vggt_backend)
-    vggt_upload_mode = str(body.get("vggt_upload_mode", "video"))
+    vggt_upload_mode = str(body.get("vggt_upload_mode", "images"))
+    upload_video_fps = (
+        min(float(effective_sample_fps or sample_fps or 2.0), 2.0)
+        if vggt_upload_mode == "video"
+        else None
+    )
     vggt_timeout = int(body.get("vggt_timeout", 900) or 900)
     conf_thres = float(body.get("vggt_conf_thres", 50.0) or 50.0)
     max_points_k = float(body.get("vggt_max_points_k", 1000.0) or 1000.0)
@@ -448,6 +458,7 @@ def scene_summary(scene_dir: Path, scenes_root: Path, app_base: str = "") -> dic
         "sample_fps": manifest.get("sample_fps") or metadata.get("sample_fps") or "",
         "crop_preset": manifest.get("crop_preset") or metadata.get("crop_preset") or "",
         "target_frames": manifest.get("target_frames", metadata.get("target_frames", "")),
+        "quality": manifest.get("quality") or metadata.get("quality") or None,
         "scale_m_per_unit": state.get("scale_m_per_unit") or manifest.get("default_scale_m_per_unit") or "",
         "scale_saved": bool(state.get("saved")),
         "job_id": manifest.get("job_id") or "",
@@ -854,11 +865,13 @@ MODEL_INPUT_ASPECT = 720.0 / 368.0
 def ffmpeg_filter(crop_preset: str, width: int, sample_fps: float) -> str:
     parts = [f"fps={sample_fps:g}"]
     if crop_preset == "central_clean":
+        ref_w, ref_h = CENTRAL_CLEAN_REFERENCE_SIZE
+        x, y, crop_w, crop_h = CENTRAL_CLEAN_REFERENCE_BBOX
         parts.append(
-            "crop=trunc(iw*660/848/2)*2:"
-            "trunc(ih*280/478/2)*2:"
-            "trunc(iw*120/848/2)*2:"
-            "trunc(ih*190/478/2)*2"
+            f"crop=trunc(iw*{crop_w}/{ref_w}/2)*2:"
+            f"trunc(ih*{crop_h}/{ref_h}/2)*2:"
+            f"trunc(iw*{x}/{ref_w}/2)*2:"
+            f"trunc(ih*{y}/{ref_h}/2)*2"
         )
     elif crop_preset == "full_frame":
         # Central crop to the model's input aspect, keeping as much of the frame
@@ -1023,7 +1036,9 @@ def probe_source_fps(video_path: Path) -> float:
 def crop_rect_norm(crop_preset: str, iw: int, ih: int) -> tuple[float, float, float, float]:
     """Crop rectangle in normalized original-frame coords (x0,y0,x1,y1)."""
     if crop_preset == "central_clean":
-        return (120 / 848, 190 / 478, (120 + 660) / 848, (190 + 280) / 478)
+        ref_w, ref_h = CENTRAL_CLEAN_REFERENCE_SIZE
+        x, y, width, height = CENTRAL_CLEAN_REFERENCE_BBOX
+        return (x / ref_w, y / ref_h, (x + width) / ref_w, (y + height) / ref_h)
     if crop_preset == "full_frame":
         aspect = MODEL_INPUT_ASPECT
         src = iw / max(1, ih)
@@ -1144,6 +1159,7 @@ def extract_frames(
     exclusion_masks: list[dict[str, object]] | None = None,
     client_sky_seg: bool = False,
     drop_black_luma: float = 0.0,
+    encode_upload_video: bool = False,
 ) -> dict[str, object]:
     frames_dir = scene_dir / "frames"
     tmp_root = scene_dir / "_extract_tmp"
@@ -1360,30 +1376,35 @@ def extract_frames(
         writer = csv.DictWriter(handle, fieldnames=list(out_rows[0].keys()))
         writer.writeheader()
         writer.writerows(out_rows)
-    input_video = scene_dir / "vggt_input.mp4"
-    upload_video_fps = min(sample_fps, 2.0)
-    run_command(
-        [
-            "ffmpeg",
-            "-v",
-            "error",
-            "-y",
-            "-framerate",
-            f"{upload_video_fps:g}",
-            "-i",
-            str(frames_dir / "f_%06d.jpg"),
-            "-c:v",
-            "libx264",
-            "-pix_fmt",
-            "yuv420p",
-            "-movflags",
-            "+faststart",
-            str(input_video),
-        ],
-        job,
-        timeout=900,
-    )
-    job.log(f"[frames] wrote {len(out_rows)} frame(s); encoded VGGT upload video at {upload_video_fps:g} fps")
+    upload_video_fps = None
+    if encode_upload_video:
+        input_video = scene_dir / "vggt_input.mp4"
+        upload_video_fps = min(sample_fps, 2.0)
+        run_command(
+            [
+                "ffmpeg",
+                "-v",
+                "error",
+                "-y",
+                "-framerate",
+                f"{upload_video_fps:g}",
+                "-i",
+                str(frames_dir / "f_%06d.jpg"),
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                "-movflags",
+                "+faststart",
+                str(input_video),
+            ],
+            job,
+            timeout=900,
+        )
+        job.log(f"[frames] wrote {len(out_rows)} frame(s); encoded VGGT upload video at {upload_video_fps:g} fps")
+    else:
+        (scene_dir / "vggt_input.mp4").unlink(missing_ok=True)
+        job.log(f"[frames] wrote {len(out_rows)} frame(s); direct image upload enabled")
     return {
         "frame_count": len(out_rows),
         "candidate_frames": len(candidates),
@@ -1427,6 +1448,40 @@ def maybe_render_camera_views(state: ToolState, scene_dir: Path, frame_count: in
         )
     except Exception as exc:
         job.log(f"[views] skipped camera-view renders: {exc}")
+
+
+def collect_vggt_quality(state: ToolState, scene_dir: Path, body: dict[str, object], job: Job) -> dict[str, object] | None:
+    """Read raw Omega confidence statistics while the RunPod upload still exists."""
+    target_path = scene_dir / "vggt_target_dir.txt"
+    if not target_path.exists():
+        job.log("[quality] no Omega target directory was recorded")
+        return None
+    command = [
+        state.python,
+        str(ROOT / "tools" / "pipeline" / "omega_pod.py"),
+        "confidence",
+        "--pod-id",
+        str(body.get("omega_pod_id") or os.environ.get("RUNPOD_POD_ID", "7i0jtqk99phk2j")),
+        "--target-dir",
+        target_path.read_text().strip(),
+        "--percentile",
+        str(float(body.get("vggt_conf_thres", 50.0) or 50.0)),
+    ]
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, timeout=150)
+        if result.returncode:
+            raise RuntimeError(result.stderr.strip() or result.stdout.strip())
+        quality = json.loads(result.stdout.strip().splitlines()[-1])
+        (scene_dir / "scene_quality.json").write_text(json.dumps(quality, indent=2))
+        job.log(
+            "[quality] raw Omega confidence "
+            f"median={quality['confidence']['median']} "
+            f"frame_p10={quality['frame_median']['p10']}"
+        )
+        return quality
+    except Exception as exc:
+        job.log(f"[quality] unavailable: {exc}")
+        return None
 
 
 def reconstruct_scene(state: ToolState, job: Job, body: dict[str, object]) -> None:
@@ -1494,6 +1549,7 @@ def reconstruct_scene(state: ToolState, job: Job, body: dict[str, object]) -> No
             adaptive=body.get("adaptive_fps") if isinstance(body.get("adaptive_fps"), dict) else None,
             exclusion_masks=body.get("exclusion_masks") if isinstance(body.get("exclusion_masks"), list) else None,
             client_sky_seg=body_bool(body, "client_sky_seg", False),
+            encode_upload_video=str(body.get("vggt_upload_mode", "images")) == "video",
         )
         frame_count = int(frame_info["frame_count"])
         manifest.update(
@@ -1544,7 +1600,7 @@ def reconstruct_scene(state: ToolState, job: Job, body: dict[str, object]) -> No
                 "--upload-mode",
                 str(vggt_config["upload_mode"]),
                 "--video-sample-fps",
-                str(float(vggt_config["upload_video_fps"])),
+                str(float(vggt_config["upload_video_fps"] or 2.0)),
             ]
             if vggt_config["mask_sky"]:
                 vggt_cmd.append("--mask-sky")
@@ -1557,6 +1613,12 @@ def reconstruct_scene(state: ToolState, job: Job, body: dict[str, object]) -> No
                 job,
                 timeout=int(vggt_config["timeout_s"]) + 120,
             )
+
+            quality = collect_vggt_quality(state, scene_dir, body, job)
+            if quality is not None:
+                manifest["quality"] = quality
+                (scene_dir / "scene_manifest.json").write_text(json.dumps(manifest, indent=2))
+                (scene_dir / "metadata.json").write_text(json.dumps(manifest, indent=2))
 
         set_job_state(state, job, step="extract_vggt")
         update_scene_manifest(scene_dir, {"job_status": job.status, "job_step": job.step, "updated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())})

--- a/tools/server/fpv_tool_server.py
+++ b/tools/server/fpv_tool_server.py
@@ -294,6 +294,10 @@ class ToolState:
     def save_job(self, job: Job) -> None:
         payload = {**job.to_json(), "request": job.request}
         path = self.job_path(job.id)
+        # A batch cleanup can remove generated scene data while this server is
+        # still alive. Recreate the runtime ledger instead of turning a newly
+        # accepted reconstruction into an opaque HTTP 500.
+        path.parent.mkdir(parents=True, exist_ok=True)
         tmp = path.with_suffix(".json.tmp")
         tmp.write_text(json.dumps(payload, indent=2))
         tmp.replace(path)


### PR DESCRIPTION
## What changed
- checkpoint Omega batch results atomically after every resolved scene and merge retries by scene id
- retry transient local tool-server errors and keep output roots consistent between the server and runner
- clear only RunPod's transient Gradio upload cache before/between sequential jobs to prevent workspace exhaustion
- fail clearly on wrapper/server output-root mismatches and recreate a removed job ledger directory
- pause the completed one-off Omega monitor and add focused regression coverage

## Verification
- 
- 
- [reconstruct] preset=clean scenes:
    annotations/2026-05-26_anti_drone_platform_biranit_annotations.json
- 