### PR TITLE
Load local scene browser from CloudFront catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ An interactive map view is available in [index.html](index.html). It is backed b
 The checked-in [`data/catalog.json`](data/catalog.json) is the single source of
 truth for video identity and descriptive metadata. README rows,
 `tools/apps/annotator/catalog-videos.json`, and the public web manifest are generated from it.
+The scene browser reads the published `scenePath` entries in `data/videos.json`
+and loads each viewer bundle directly from CloudFront; local `scenes/` folders
+are only reconstruction workspaces, not a second runtime catalog.
 
 ## Repository layout
 

--- a/tools/apps/scene-browser/index.html
+++ b/tools/apps/scene-browser/index.html
@@ -77,13 +77,6 @@
       cursor: pointer;
       white-space: nowrap;
     }
-    .hdr-btns {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      margin-left: auto;
-      flex-shrink: 0;
-    }
     .status {
       padding: 18px;
       color: #8fa0ad;
@@ -101,14 +94,11 @@
     <select id="sceneSelect" aria-label="Scene">
       <option value="">Loading scenes...</option>
     </select>
-    <div class="hdr-btns">
-      <button id="addFolderButton" type="button">Add Folder</button>
-    </div>
   </header>
   <div class="status" id="statusText"></div>
+  <script src="/tools/apps/shared/published-scenes.js"></script>
   <script>
     const sceneSelect = document.getElementById("sceneSelect");
-    const addFolderButton = document.getElementById("addFolderButton");
     const statusText = document.getElementById("statusText");
     let scenes = [];
 
@@ -129,13 +119,11 @@
     }
 
     async function loadScenes() {
-      const response = await fetch("/api/scenes", { cache: "no-store" });
-      const payload = await response.json();
-      scenes = (payload.scenes || []).filter((scene) => scene.exists && scene.viewer_url);
+      scenes = await window.loadPublishedScenes();
       sceneSelect.innerHTML = "";
       if (!scenes.length) {
-        sceneSelect.innerHTML = '<option value="">No saved scenes</option>';
-        statusText.textContent = "Run VGGT from the annotator or add an existing scene folder.";
+        sceneSelect.innerHTML = '<option value="">No published scenes</option>';
+        statusText.textContent = "No scenes are listed in the published catalog.";
         return;
       }
       const placeholder = document.createElement("option");
@@ -151,28 +139,6 @@
         sceneSelect.appendChild(option);
       }
       statusText.textContent = "Select a scene from the dropdown to open it.";
-    }
-
-    async function addFolder() {
-      const sourcePath = window.prompt("Scene folder path to copy into the repo");
-      if (!sourcePath) return;
-      statusText.textContent = "Adding scene folder...";
-      const response = await fetch("/api/scenes/import", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ source_path: sourcePath })
-      });
-      const payload = await response.json();
-      if (!response.ok) {
-        statusText.textContent = payload.error || "Could not add folder.";
-        return;
-      }
-      await loadScenes();
-      if (payload.scene?.scene_id) {
-        sceneSelect.value = payload.scene.scene_id;
-        statusText.textContent = payload.imported === false ? "Scene folder is already in the repo." : "Scene folder added.";
-        openSelected();
-      }
     }
 
     // Deep-link: /scenes/?scene=<scene_id> opens that scene's viewer directly.
@@ -191,7 +157,6 @@
     }
 
     sceneSelect.addEventListener("change", openSelected);
-    addFolderButton.addEventListener("click", addFolder);
     loadScenes().then(applySceneFromQuery).catch((error) => {
       sceneSelect.innerHTML = '<option value="">Could not load scenes</option>';
       statusText.textContent = error.message;

--- a/tools/apps/scene-viewer/index.html
+++ b/tools/apps/scene-viewer/index.html
@@ -97,6 +97,7 @@
     </form>
   </dialog>
   <script>window.SCENE_BASE = "__SCENE_BASE__"; window.APP_BASE = "__APP_BASE__"; window.API_BASE = "__API_BASE__";</script>
+  <script src="__APP_BASE__/tools/apps/shared/published-scenes.js"></script>
   <script type="importmap">
     {
       "imports": {

--- a/tools/apps/scene-viewer/viewer.js
+++ b/tools/apps/scene-viewer/viewer.js
@@ -240,10 +240,7 @@ const canvas = document.getElementById("viewer");
     async function loadSceneOptions() {
       if (!sceneSelectTop) return;
       try {
-        const response = await fetch(apiUrl("/api/scenes"), { cache: "no-store" });
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
-        const payload = await response.json();
-        const scenes = (payload.scenes || []).filter((scene) => scene.exists && scene.viewer_url);
+        const scenes = await window.loadPublishedScenes();
         sceneSelectTop.innerHTML = "";
         if (!scenes.length) {
           sceneSelectTop.innerHTML = '<option value="">No saved scenes</option>';

--- a/tools/apps/shared/published-scenes.js
+++ b/tools/apps/shared/published-scenes.js
@@ -1,0 +1,45 @@
+(() => {
+  const CATALOG_URL = "https://d2fioemadmrru3.cloudfront.net/data/videos.json";
+  let scenesPromise;
+
+  function viewerUrl(scenePath) {
+    const encodedPath = scenePath.split("/").map(encodeURIComponent).join("/");
+    return `/scenes/${encodedPath}/viewer/index.html`;
+  }
+
+  function sceneFromVideo(video) {
+    const scenePath = typeof video.scenePath === "string" ? video.scenePath.trim().replace(/^\/+|\/+$/g, "") : "";
+    if (!scenePath || scenePath.split("/").some((part) => !part || part === "." || part === "..")) return null;
+    const parts = scenePath.split("/");
+    return {
+      scene_id: parts.at(-1),
+      path: scenePath,
+      viewer_url: viewerUrl(scenePath),
+      exists: true,
+      video_file: video.videoFile || "",
+      description: video.description || "",
+      date: video.date || "",
+      town: video.town || "",
+      segment_ids: parts.at(-1).split("_").filter((part) => /^seg\d+$/i.test(part)),
+    };
+  }
+
+  window.loadPublishedScenes = function loadPublishedScenes() {
+    if (!scenesPromise) {
+      scenesPromise = fetch(`${CATALOG_URL}?cache=${Date.now()}`, { cache: "no-store" })
+        .then((response) => {
+          if (!response.ok) throw new Error(`Published scene catalog HTTP ${response.status}`);
+          return response.json();
+        })
+        .then((payload) => {
+          const byPath = new Map();
+          for (const video of payload.videos || []) {
+            const scene = sceneFromVideo(video);
+            if (scene) byPath.set(scene.path, scene);
+          }
+          return [...byPath.values()];
+        });
+    }
+    return scenesPromise;
+  };
+})();

--- a/tools/apps/shared/test_published_scenes.mjs
+++ b/tools/apps/shared/test_published_scenes.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import vm from "node:vm";
+
+const source = fs.readFileSync(new URL("./published-scenes.js", import.meta.url), "utf8");
+const sandbox = {
+  Date: { now: () => 123 },
+  encodeURIComponent,
+  window: {},
+  fetch: async () => ({
+    ok: true,
+    json: async () => ({
+      videos: [
+        {
+          videoFile: "flight.mp4",
+          date: "2026-07-13",
+          description: "Test flight",
+          town: "Test town",
+          scenePath: "flight/flight_seg01_seg02",
+        },
+        { videoFile: "no-scene.mp4", scenePath: null },
+        { videoFile: "invalid.mp4", scenePath: "flight/../invalid" },
+      ],
+    }),
+  }),
+};
+vm.runInNewContext(source, sandbox);
+const scenes = await sandbox.window.loadPublishedScenes();
+
+assert.equal(scenes.length, 1);
+assert.deepEqual(JSON.parse(JSON.stringify(scenes[0])), {
+  scene_id: "flight_seg01_seg02",
+  path: "flight/flight_seg01_seg02",
+  viewer_url: "/scenes/flight/flight_seg01_seg02/viewer/index.html",
+  exists: true,
+  video_file: "flight.mp4",
+  description: "Test flight",
+  date: "2026-07-13",
+  town: "Test town",
+  segment_ids: ["seg01", "seg02"],
+});
+console.log("published scene catalog client: ok");

--- a/tools/server/fpv_tool_server.py
+++ b/tools/server/fpv_tool_server.py
@@ -32,7 +32,7 @@ SERVER_DIR = Path(__file__).resolve().parent
 if str(SERVER_DIR) not in sys.path:
     sys.path.insert(0, str(SERVER_DIR))
 
-from asset_urls import asset_root_from_env, scene_data_base, scene_viewer_page_url
+from asset_urls import DEFAULT_CLOUDFRONT_ROOT, asset_root_from_env, scene_data_base, scene_viewer_page_url
 DEFAULT_OUT_DIR = ROOT
 DEFAULT_VIDEO_CACHE = Path("/tmp/fpv-model-benchmark/videos")
 GENERIC_VIEWER_INDEX = ROOT / "tools" / "apps" / "scene-viewer" / "index.html"
@@ -762,9 +762,8 @@ class FPVRequestHandler(SimpleHTTPRequestHandler):
         thread.start()
         write_json(self, {"job_id": job.id, "scene_id": scene_id, "viewer_url": job.viewer_url}, status=202)
 
-    def serve_generic_scene_viewer(self, viewer_dir: Path) -> None:
-        rel_scene = viewer_dir.parent.relative_to(self.state.scenes_dir).as_posix()
-        scene_base = scene_data_base(rel_scene, self.state.asset_root)
+    def serve_generic_scene_viewer(self, rel_scene: str, asset_root: str = "") -> None:
+        scene_base = scene_data_base(rel_scene, asset_root)
         data = read_generic_viewer_html(scene_base, self.state.app_base, "")
         self.send_response(200)
         self.send_header("Content-Type", "text/html; charset=utf-8")
@@ -776,7 +775,19 @@ class FPVRequestHandler(SimpleHTTPRequestHandler):
     def serve_static(self, path: str) -> None:
         viewer_dir = scene_viewer_dir(self.state.scenes_dir, path)
         if viewer_dir is not None:
-            self.serve_generic_scene_viewer(viewer_dir)
+            rel_scene = viewer_dir.parent.relative_to(self.state.scenes_dir).as_posix()
+            self.serve_generic_scene_viewer(rel_scene, self.state.asset_root)
+            return
+        remote_viewer = SCENE_VIEWER_INDEX_RE.match(path)
+        if remote_viewer:
+            rel_scene = unquote(remote_viewer.group(1))
+            if any(part in {"", ".", ".."} for part in rel_scene.split("/")):
+                write_error(self, "invalid scene path", status=400)
+                return
+            # Published viewer data lives on CloudFront. The browser discovers
+            # valid scene paths from data/videos.json; this local shell then
+            # loads the selected bundle directly from that public source.
+            self.serve_generic_scene_viewer(rel_scene, self.state.asset_root or DEFAULT_CLOUDFRONT_ROOT)
             return
         aliases = {
             "/tools/annotator.html": "/tools/apps/annotator/index.html",


### PR DESCRIPTION
## Summary
- load published scenes in the scene browser and viewer dropdown directly from CloudFront 
- use each manifest  to open the local generic viewer shell, which streams scene data from CloudFront
- remove the local scene-folder import flow from the browser
- add a focused catalog-client regression test and reject encoded invalid scene paths

## Verification
- published scene catalog client: ok
- 
- local server health check on port 8767
- verified a real published scene shell resolves to CloudFront assets
- verified encoded invalid paths return HTTP 400
- 