### PR TITLE
Update camera frame during scene playback

### DIFF
--- a/tools/apps/scene-viewer/viewer.js
+++ b/tools/apps/scene-viewer/viewer.js
@@ -919,7 +919,6 @@ const canvas = document.getElementById("viewer");
       );
       drawTopView(scale);
       updateTelemetry(series);
-      updateCameraView();
     }
 
     function currentSceneBox() {
@@ -1006,6 +1005,9 @@ const canvas = document.getElementById("viewer");
       progress.value = String(frameIndex);
       frameValue.textContent = String(frame.frame);
       playbackTimeS = frameTime(frame);
+      // Keep the camera-frame image in lockstep with animation. Plot rendering
+      // can be comparatively expensive and should not delay this visual cue.
+      updateCameraView();
       drawPlots();
     }
 


### PR DESCRIPTION
Refresh the camera-frame panel directly when the playback frame changes, instead of waiting for telemetry plots to redraw.