### PR TITLE
Add starred 3D scene curation

### DIFF
--- a/data/scene-curation.json
+++ b/data/scene-curation.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "starred_scene_ids": [
+    "2026-04-24_d9_engineering_vehicle_between_taybeh_and_deir_siryan",
+    "2026-05-02_strike_on_namer_apc_in_bint_jbeil",
+    "2026-05-05_strike_on_merkava_tank",
+    "2026-05-06_strike_on_namer_apc_near_deir_siryan",
+    "2026-05-14_soldiers_gathering_naqoura_ras_naqoura_mmirleb_16294",
+    "2026-05-22_merkava_tank_markaba",
+    "2026-05-22_soldier_manara",
+    "2026-05-24_humvee_manara_mmirleb_16823",
+    "2026-05-24_namer_apc_taybeh",
+    "2026-05-26_anti_drone_platform_biranit",
+    "2026-05-28_iron_dome_launcher_vehicle_khiam_mmirleb_16993",
+    "2026-05-28_merkava_tank_zawtar_al_sharqiyah_mmirleb_17154",
+    "2026-05-29_soldier_at_misgav_am",
+    "2026-06-01_merkava_tank_near_yahmor_al_shqif",
+    "2026-06-03_humvee_zawtar_al_sharqiyah",
+    "2026-06-03_m113_apc_beaufort_castle",
+    "2026-06-04_merkava_tank_beaufort_castle_02",
+    "2026-06-06_artillery_vehicle_adaissah_mmirleb_17504",
+    "2026-06-07_command_namer_vehicle_yahmor_al_shqif",
+    "2026-06-07_merkava_tank_beaufort_castle",
+    "2026-06-08_strike_on_enemy_vehicles_near_yahmor_al_shqif",
+    "2026-06-09_namer_apc_metula_southern_outskirts_khiam",
+    "2026-06-13_command_center_beaufort_castle_mmirleb_17580",
+    "2026-06-13_logistics_position_bayyadah_mmirleb_17434",
+    "2026-06-13_namer_vehicle_hamammas_hill_khiam_mmirleb_17586",
+    "2026-06-14_engineering_vehicle_arnoun_ababil_drone"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "dataset:add": "node tools/catalog/dataset.mjs add",
     "dataset:annotate": "node tools/catalog/dataset.mjs annotate",
     "dataset:add-scene": "node tools/catalog/dataset.mjs add-scene",
+    "dataset:star-scenes": "node tools/catalog/dataset.mjs star-scenes",
+    "dataset:unstar-scenes": "node tools/catalog/dataset.mjs unstar-scenes",
     "dataset:unpublish-scenes": "node tools/catalog/dataset.mjs unpublish-scenes",
     "dataset:rename": "node tools/catalog/dataset.mjs rename",
     "dataset:publish": "node tools/catalog/dataset.mjs publish",

--- a/tools/catalog/dataset.mjs
+++ b/tools/catalog/dataset.mjs
@@ -92,6 +92,15 @@ function sceneIds(opts) {
   return ids;
 }
 
+function sceneCuration() {
+  const file = path.join(root, "data", "scene-curation.json");
+  const value = readJson(file);
+  if (value.schema_version !== 1 || !Array.isArray(value.starred_scene_ids)) {
+    throw new Error("data/scene-curation.json must contain schema_version 1 and starred_scene_ids");
+  }
+  return { file, value };
+}
+
 function loadState() {
   return {
     catalog: readJson(path.join(root, "data/catalog.json")),
@@ -180,6 +189,29 @@ function addScene(opts) {
     viewer_key: `scenes/${id}/${sceneId}/viewer/scene_meta.json`,
   });
   console.log(`registered scene ${sceneId}; run dataset:publish with this local scenes directory present`);
+}
+
+async function setSceneStarred(opts, starred) {
+  const ids = sceneIds(opts);
+  const state = loadState();
+  const catalogIds = new Set(state.catalog.videos.map((video) => video.id));
+  const unknown = ids.filter((id) => !catalogIds.has(id));
+  if (unknown.length) throw new Error(`unknown catalog IDs: ${unknown.join(", ")}`);
+
+  const response = await fetch(`${CDN_BASE}/data/videos.json?starred-scenes=${Date.now()}`);
+  if (!response.ok) throw new Error(`could not fetch current web manifest: HTTP ${response.status}`);
+  const published = new Map((await response.json()).videos?.map((video) => [video.slug, video]));
+  const withoutScene = ids.filter((id) => !published.get(id)?.scenePath);
+  if (withoutScene.length) throw new Error(`cannot star videos without a published scene: ${withoutScene.join(", ")}`);
+
+  const { file, value } = sceneCuration();
+  const curated = new Set(value.starred_scene_ids);
+  for (const id of ids) {
+    if (starred) curated.add(id);
+    else curated.delete(id);
+  }
+  writeJson(file, { ...value, starred_scene_ids: [...curated].sort() });
+  console.log(`${starred ? "starred" : "unstarred"} ${ids.length} scene(s); run dataset:publish to update CloudFront`);
 }
 
 async function unpublishScenes(opts) {
@@ -311,6 +343,8 @@ function help() {
   npm run dataset:add -- --video FILE --thumbnail FILE --metadata JSON [--no-upload]
   npm run dataset:annotate -- --id ID --annotation JSON
   npm run dataset:add-scene -- --id ID --scene DIR
+  npm run dataset:star-scenes -- --ids ID,ID
+  npm run dataset:unstar-scenes -- --ids ID,ID
   npm run dataset:unpublish-scenes -- --ids ID,ID [--execute]
   npm run dataset:rename -- --from ID --to ID --reason TEXT [--review-after DATE] --execute
   npm run dataset:publish
@@ -321,6 +355,8 @@ const opts = options(rawArgs);
 if (command === "add") await add(opts);
 else if (command === "annotate") annotate(opts);
 else if (command === "add-scene") addScene(opts);
+else if (command === "star-scenes") await setSceneStarred(opts, true);
+else if (command === "unstar-scenes") await setSceneStarred(opts, false);
 else if (command === "unpublish-scenes") await unpublishScenes(opts);
 else if (command === "rename") await rename(opts);
 else if (command === "publish") run("bash", ["tools/publishing/publish_web.sh", ...(opts["skip-scenes"] ? ["--skip-scenes"] : [])]);

--- a/tools/publishing/build_web_data.mjs
+++ b/tools/publishing/build_web_data.mjs
@@ -31,6 +31,15 @@ function readCatalogVideos() {
   return sortedRecords(readJson(path.join(repoRoot, "data/catalog.json"))).map(publicVideo);
 }
 
+function readStarredSceneIds() {
+  const file = path.join(repoRoot, "data", "scene-curation.json");
+  const curation = readJson(file);
+  if (curation.schema_version !== 1 || !Array.isArray(curation.starred_scene_ids)) {
+    throw new Error("data/scene-curation.json must contain schema_version 1 and starred_scene_ids");
+  }
+  return new Set(curation.starred_scene_ids);
+}
+
 // Prefer a manual annotation (no auto_generated flag) over an auto one.
 function readAnnotations() {
   const dir = path.join(repoRoot, "annotations");
@@ -92,6 +101,7 @@ function readPreviousVideoFiles() {
 
 const annotations = readAnnotations();
 const sceneIndex = buildSceneIndex();
+const starredSceneIds = readStarredSceneIds();
 const thumbs = readThumbManifest();
 const existingVideos = readExistingVideos();
 const previousVideoFiles = readPreviousVideoFiles();
@@ -122,6 +132,7 @@ for (const raw of readCatalogVideos()) {
     thumbWidths: thumb?.widths ?? existing?.thumbWidths ?? null,
     blur: thumb?.blurDataURL ?? existing?.blur ?? null,
     scenePath,
+    sceneStarred: Boolean(scenePath && starredSceneIds.has(slug)),
     sceneQuality: scene?.quality ?? existing?.sceneQuality ?? null,
     segments: ann?.segments ?? null,
     annotationAuto: ann ? Boolean(ann.auto_generated) : null,


### PR DESCRIPTION
## Summary
- add a Git-tracked list of starred 3D scenes
- publish the flag as `sceneStarred` in the CloudFront video catalog
- add `dataset:star-scenes` and `dataset:unstar-scenes`

## Data
- starred the 26 scenes selected in this task
- verified the raw S3 catalog contains 26 starred scenes, including `2026-06-01_merkava_tank_near_yahmor_al_shqif`

## Tests
- `npm run catalog:check`
- rebuilt the web manifest from the live catalog: 102 scenes retained, 26 starred