### PR TITLE
Add searchable local video pickers

### DIFF
--- a/tools/apps/annotator/index.html
+++ b/tools/apps/annotator/index.html
@@ -50,6 +50,11 @@ header{position:relative;z-index:1000;display:flex;align-items:center;gap:10px;p
   max-height:min(620px,calc(100vh - 76px));overflow:auto;background:#101216;
   border:1px solid rgba(255,255,255,.16);border-radius:8px;box-shadow:0 18px 60px rgba(0,0,0,.48);
   padding:4px}
+.video-picker-search{width:100%;min-height:32px;margin-bottom:4px;padding:0 9px;
+  border:1px solid rgba(255,255,255,.14);border-radius:6px;background:rgba(255,255,255,.07);
+  color:var(--text);font:inherit;font-size:13px;outline:none}
+.video-picker-search:focus{border-color:var(--accent)}
+.video-picker-empty{padding:9px;color:var(--muted);font-size:13px}
 .video-picker-option{width:100%;display:flex;align-items:center;gap:8px;padding:7px 8px;
   border:0;border-radius:6px;background:transparent;color:var(--text);text-align:left;font-size:13px}
 .video-picker-option:hover,.video-picker-option.active{background:rgba(86,215,255,.10)}
@@ -670,11 +675,20 @@ function selectVideoByIndex(index) {
   if (video) loadVideo(video);
 }
 
-function renderVideoPickerMenu() {
-  const menu = g('videoPickerMenu');
+function videoPickerLabel(video) {
+  return `${video.date} - ${video.description} (${video.town})`;
+}
+
+function videoPickerSearchText(video) {
+  return `${videoPickerLabel(video)} ${videoFileFor(video)}`.toLowerCase();
+}
+
+function renderVideoPickerOptions(menu, query = '') {
   const selected = g('videoSelect').value;
-  menu.innerHTML = '';
-  VIDEOS.forEach((video, index) => {
+  const normalizedQuery = query.trim().toLowerCase();
+  const matches = VIDEOS.filter(video => !normalizedQuery || videoPickerSearchText(video).includes(normalizedQuery));
+  for (const video of matches) {
+    const index = VIDEOS.indexOf(video);
     const statusName = videoStatusFor(video);
     const row = document.createElement('button');
     row.type = 'button';
@@ -684,16 +698,42 @@ function renderVideoPickerMenu() {
     dot.className = `status-dot ${statusName}`;
     const text = document.createElement('span');
     text.className = 'video-picker-label';
-    text.textContent = `${video.date} - ${video.description} (${video.town})`;
+    text.textContent = videoPickerLabel(video);
     row.append(dot, text);
     row.addEventListener('click', () => selectVideoByIndex(index));
     menu.appendChild(row);
+  }
+  if (!matches.length) {
+    const empty = document.createElement('div');
+    empty.className = 'video-picker-empty';
+    empty.textContent = 'No videos match this search.';
+    menu.appendChild(empty);
+  }
+}
+
+function renderVideoPickerMenu() {
+  const menu = g('videoPickerMenu');
+  menu.innerHTML = '';
+  const search = document.createElement('input');
+  search.type = 'search';
+  search.className = 'video-picker-search';
+  search.placeholder = 'Search videos';
+  search.autocomplete = 'off';
+  search.setAttribute('aria-label', 'Search videos');
+  const options = document.createElement('div');
+  search.addEventListener('input', () => {
+    options.innerHTML = '';
+    renderVideoPickerOptions(options, search.value);
   });
+  menu.append(search, options);
+  renderVideoPickerOptions(options);
+  return search;
 }
 
 function openVideoPicker() {
-  renderVideoPickerMenu();
+  const search = renderVideoPickerMenu();
   g('videoPickerMenu').hidden = false;
+  requestAnimationFrame(() => search.focus());
 }
 
 function closeVideoPicker() {

--- a/tools/apps/scene-browser/index.html
+++ b/tools/apps/scene-browser/index.html
@@ -55,7 +55,7 @@
       border-color: #36e4ff;
       font-weight: 800;
     }
-    select, button {
+    input, select, button {
       min-height: 32px;
       border: 1px solid rgba(255, 255, 255, 0.14);
       border-radius: 8px;
@@ -63,15 +63,23 @@
       background: rgba(255, 255, 255, 0.08);
       font: 13px ui-sans-serif, system-ui, sans-serif;
     }
-    select {
+    .scene-picker {
+      display: grid;
+      grid-template-columns: minmax(150px, 0.7fr) minmax(180px, 1.3fr);
+      flex: 1;
+      gap: 6px;
+      min-width: 0;
+      max-width: 520px;
+    }
+    input, select {
       flex: 1;
       width: 100%;
-      max-width: 520px;
       min-width: 0;
       padding: 0 8px;
       text-transform: none;
       letter-spacing: 0;
     }
+    input:focus { outline: none; border-color: #36e4ff; }
     button {
       padding: 0 12px;
       cursor: pointer;
@@ -91,14 +99,18 @@
       <a href="/annotate/">Annotate</a>
       <a class="active" href="/scenes/">Scenes</a>
     </nav>
-    <select id="sceneSelect" aria-label="Scene">
-      <option value="">Loading scenes...</option>
-    </select>
+    <div class="scene-picker">
+      <input id="sceneSearch" type="search" placeholder="Search scenes" aria-label="Search scenes" autocomplete="off" />
+      <select id="sceneSelect" aria-label="Scene">
+        <option value="">Loading scenes...</option>
+      </select>
+    </div>
   </header>
   <div class="status" id="statusText"></div>
   <script src="/tools/apps/shared/published-scenes.js"></script>
   <script>
     const sceneSelect = document.getElementById("sceneSelect");
+    const sceneSearch = document.getElementById("sceneSearch");
     const statusText = document.getElementById("statusText");
     let scenes = [];
 
@@ -111,6 +123,34 @@
       return `${prefix}${scene.description || scene.scene_id}`;
     }
 
+    function sceneSearchText(scene) {
+      return `${formatScene(scene)} ${scene.video_file || ""} ${scene.scene_id || ""}`.toLowerCase();
+    }
+
+    function renderSceneOptions() {
+      const query = sceneSearch.value.trim().toLowerCase();
+      const matches = scenes.filter((scene) => !query || sceneSearchText(scene).includes(query));
+      sceneSelect.innerHTML = "";
+      if (!matches.length) {
+        sceneSelect.innerHTML = '<option value="">No scenes match this search</option>';
+        sceneSelect.disabled = true;
+        return;
+      }
+      const placeholder = document.createElement("option");
+      placeholder.value = "";
+      placeholder.textContent = "Select a scene...";
+      placeholder.selected = true;
+      placeholder.disabled = true;
+      sceneSelect.appendChild(placeholder);
+      for (const scene of matches) {
+        const option = document.createElement("option");
+        option.value = scene.scene_id;
+        option.textContent = formatScene(scene);
+        sceneSelect.appendChild(option);
+      }
+      sceneSelect.disabled = false;
+    }
+
     function openSelected() {
       if (!sceneSelect.value) return;
       const scene = scenes.find((item) => item.scene_id === sceneSelect.value);
@@ -120,24 +160,14 @@
 
     async function loadScenes() {
       scenes = await window.loadPublishedScenes();
-      sceneSelect.innerHTML = "";
       if (!scenes.length) {
         sceneSelect.innerHTML = '<option value="">No published scenes</option>';
+        sceneSelect.disabled = true;
+        sceneSearch.disabled = true;
         statusText.textContent = "No scenes are listed in the published catalog.";
         return;
       }
-      const placeholder = document.createElement("option");
-      placeholder.value = "";
-      placeholder.textContent = "Select a scene...";
-      placeholder.selected = true;
-      placeholder.disabled = true;
-      sceneSelect.appendChild(placeholder);
-      for (const scene of scenes) {
-        const option = document.createElement("option");
-        option.value = scene.scene_id;
-        option.textContent = formatScene(scene);
-        sceneSelect.appendChild(option);
-      }
+      renderSceneOptions();
       statusText.textContent = "Select a scene from the dropdown to open it.";
     }
 
@@ -157,8 +187,11 @@
     }
 
     sceneSelect.addEventListener("change", openSelected);
+    sceneSearch.addEventListener("input", renderSceneOptions);
     loadScenes().then(applySceneFromQuery).catch((error) => {
       sceneSelect.innerHTML = '<option value="">Could not load scenes</option>';
+      sceneSelect.disabled = true;
+      sceneSearch.disabled = true;
       statusText.textContent = error.message;
     });
   </script>

--- a/tools/apps/scene-viewer/index.html
+++ b/tools/apps/scene-viewer/index.html
@@ -13,11 +13,12 @@
       <a href="/annotate/" target="_top">Annotate</a>
       <a class="active" href="/scenes/" target="_top">Scenes</a>
     </nav>
-    <label class="scene-picker" for="sceneSelectTop">
+    <div class="scene-picker">
+      <input id="sceneSearchTop" type="search" placeholder="Search scenes" aria-label="Search scenes" autocomplete="off" />
       <select id="sceneSelectTop">
         <option value="">Loading scenes...</option>
       </select>
-    </label>
+    </div>
     <div class="hdr-btns">
       <button id="saveSceneButton" type="button">Save</button>
       <span id="saveStateText"></span>

--- a/tools/apps/scene-viewer/viewer.css
+++ b/tools/apps/scene-viewer/viewer.css
@@ -65,12 +65,14 @@
       font-weight: 800;
     }
     .scene-picker {
-      display: block;
+      display: grid;
+      grid-template-columns: minmax(150px, 0.7fr) minmax(180px, 1.3fr);
+      gap: 6px;
       flex: 1;
       min-width: 0;
       max-width: 520px;
     }
-    #sceneSelectTop {
+    #sceneSelectTop, #sceneSearchTop {
       min-width: 0;
       width: 100%;
       min-height: 32px;
@@ -83,6 +85,7 @@
       text-transform: none;
       letter-spacing: 0;
     }
+    #sceneSearchTop:focus { outline: none; border-color: #36e4ff; }
     #saveStateText {
       min-width: 62px;
       color: #8fa0ad;

--- a/tools/apps/scene-viewer/viewer.js
+++ b/tools/apps/scene-viewer/viewer.js
@@ -77,6 +77,7 @@ const canvas = document.getElementById("viewer");
     const title = document.getElementById("title");
     const metaEl = document.getElementById("meta");
     const sceneSelectTop = document.getElementById("sceneSelectTop");
+    const sceneSearchTop = document.getElementById("sceneSearchTop");
     const saveSceneButton = document.getElementById("saveSceneButton");
     const saveStateText = document.getElementById("saveStateText");
     const progress = document.getElementById("pathProgress");
@@ -237,28 +238,49 @@ const canvas = document.getElementById("viewer");
       return `${prefix}${scene.description || scene.scene_id}`;
     }
 
+    function sceneSearchText(scene) {
+      return `${sceneOptionLabel(scene)} ${scene.video_file || ""} ${scene.scene_id || ""}`.toLowerCase();
+    }
+
+    let publishedScenes = [];
+
+    function renderSceneOptions() {
+      if (!sceneSelectTop) return;
+      const query = sceneSearchTop?.value.trim().toLowerCase() || "";
+      const scenes = publishedScenes.filter((scene) => !query || sceneSearchText(scene).includes(query));
+      sceneSelectTop.innerHTML = "";
+      if (!scenes.length) {
+        sceneSelectTop.innerHTML = '<option value="">No scenes match this search</option>';
+        sceneSelectTop.disabled = true;
+        return;
+      }
+      for (const scene of scenes) {
+        const option = document.createElement("option");
+        option.value = scene.viewer_url;
+        option.dataset.sceneId = scene.scene_id;
+        option.textContent = sceneOptionLabel(scene);
+        if (meta?.scene_id && scene.scene_id === meta.scene_id) option.selected = true;
+        sceneSelectTop.appendChild(option);
+      }
+      sceneSelectTop.disabled = false;
+    }
+
     async function loadSceneOptions() {
       if (!sceneSelectTop) return;
       try {
-        const scenes = await window.loadPublishedScenes();
-        sceneSelectTop.innerHTML = "";
-        if (!scenes.length) {
+        publishedScenes = await window.loadPublishedScenes();
+        if (!publishedScenes.length) {
           sceneSelectTop.innerHTML = '<option value="">No saved scenes</option>';
           sceneSelectTop.disabled = true;
+          if (sceneSearchTop) sceneSearchTop.disabled = true;
           return;
         }
-        for (const scene of scenes) {
-          const option = document.createElement("option");
-          option.value = scene.viewer_url;
-          option.dataset.sceneId = scene.scene_id;
-          option.textContent = sceneOptionLabel(scene);
-          if (meta?.scene_id && scene.scene_id === meta.scene_id) option.selected = true;
-          sceneSelectTop.appendChild(option);
-        }
-        sceneSelectTop.disabled = false;
+        if (sceneSearchTop) sceneSearchTop.disabled = false;
+        renderSceneOptions();
       } catch {
         sceneSelectTop.innerHTML = '<option value="">Scenes unavailable</option>';
         sceneSelectTop.disabled = true;
+        if (sceneSearchTop) sceneSearchTop.disabled = true;
       }
     }
 
@@ -1099,6 +1121,7 @@ const canvas = document.getElementById("viewer");
     sceneSelectTop.addEventListener("change", () => {
       if (sceneSelectTop.value) window.location.href = sceneSelectTop.value;
     });
+    sceneSearchTop?.addEventListener("input", renderSceneOptions);
     saveSceneButton.addEventListener("click", () => saveCurrentScene("save_button"));
     playButton.addEventListener("click", () => setPlaying(!isPlaying));
     repeatButton.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- add filename-aware search to the annotator video picker
- add catalog search to the Scenes landing page and individual scene viewer

## Verification
- `npm run catalog:check`
- local browser checks for annotator and scene searches