### PR TITLE
Add removal tombstones so withdrawn IDs serve 410 instead of 404

### DIFF
--- a/data/redirects.json
+++ b/data/redirects.json
@@ -7,6 +7,18 @@
       "created_at": "2026-07-12",
       "review_after": "2026-10-15",
       "reason": "Correct place-name spelling"
+    },
+    {
+      "from": "2026-05-17_buggy_iskandarounah_naqoura",
+      "to": "2026-05-17_military_vehicle_bayyadah_iskandarounah_mmirleb_16443",
+      "created_at": "2026-07-26",
+      "reason": "Duplicate of the official upload of the same footage"
+    },
+    {
+      "from": "2026-05-26_humvee_vehicle_in_wadi_near_dibel",
+      "to": "2026-05-26_humvee_zawtar_al_sharqiyah_riverbed_mmirleb_17068",
+      "created_at": "2026-07-26",
+      "reason": "Duplicate filed under the wrong town; on-screen labels read Zawtar al-Sharqiyah"
     }
   ]
 }

--- a/data/removed.json
+++ b/data/removed.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "removed": [
+    {
+      "id": "2026-05-04_strike_on_engineering_vehicle",
+      "removed_at": "2026-07-13",
+      "reason": "Excluded from the dataset"
+    },
+    {
+      "id": "2026-05-06_position_point_taybeh_mmirleb_16210",
+      "removed_at": "2026-07-13",
+      "reason": "Excluded from the dataset"
+    },
+    {
+      "id": "2026-05-06_soldiers_gathering_aita_al_shaab_mmirleb_15841",
+      "removed_at": "2026-07-13",
+      "reason": "Excluded from the dataset"
+    },
+    {
+      "id": "2026-05-09_soldiers_gathering_jal_al_alam_mmirleb_15988",
+      "removed_at": "2026-07-13",
+      "reason": "Excluded from the dataset"
+    },
+    {
+      "id": "2026-05-09_soldiers_gathering_shlomi_mmirleb_15970",
+      "removed_at": "2026-07-13",
+      "reason": "Excluded from the dataset"
+    },
+    {
+      "id": "2026-05-12_humvee_naqoura_naqoura_iskandarounah_road_mmirleb_16261",
+      "removed_at": "2026-07-13",
+      "reason": "Excluded from the dataset"
+    }
+  ]
+}

--- a/data/removed.schema.json
+++ b/data/removed.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "FPV dataset tombstones",
+  "description": "IDs that were withdrawn from the catalog with no successor. The web viewer serves HTTP 410 for these so search engines drop them instead of re-crawling a 404 for months. IDs that were superseded belong in redirects.json instead.",
+  "type": "object",
+  "required": ["schema_version", "removed"],
+  "properties": {
+    "schema_version": { "const": 1 },
+    "removed": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "removed_at", "reason"],
+        "properties": {
+          "id": { "type": "string" },
+          "removed_at": { "type": "string", "format": "date" },
+          "reason": { "type": "string", "minLength": 1 }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/ops/cloudfront-uri-redirects.js
+++ b/ops/cloudfront-uri-redirects.js
@@ -10,7 +10,7 @@ function handler(event) {
   var request = event.request;
   var oldUri = request.uri;
   var newUri = oldUri;
-  var redirects = {"2026-05-26_anti_drone_platform_barashit":"2026-05-26_anti_drone_platform_biranit"};
+  var redirects = {"2026-05-26_anti_drone_platform_barashit":"2026-05-26_anti_drone_platform_biranit","2026-05-17_buggy_iskandarounah_naqoura":"2026-05-17_military_vehicle_bayyadah_iskandarounah_mmirleb_16443","2026-05-26_humvee_vehicle_in_wadi_near_dibel":"2026-05-26_humvee_zawtar_al_sharqiyah_riverbed_mmirleb_17068"};
   if (newUri.indexOf("/annotations/") === 0) {
     newUri = newUri.replace(/^\/annotations\/(\d{4})_(\d{2})_(\d{2})_/, "/annotations/$1-$2-$3_");
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dataset:unstar-scenes": "node tools/catalog/dataset.mjs unstar-scenes",
     "dataset:unpublish-scenes": "node tools/catalog/dataset.mjs unpublish-scenes",
     "dataset:rename": "node tools/catalog/dataset.mjs rename",
+    "dataset:remove": "node tools/catalog/dataset.mjs remove",
     "dataset:publish": "node tools/catalog/dataset.mjs publish",
     "dataset:verify": "node tools/catalog/dataset.mjs verify",
     "check-public": "node tools/catalog/check_public_assets.mjs",

--- a/tools/catalog/audit_catalog.mjs
+++ b/tools/catalog/audit_catalog.mjs
@@ -10,14 +10,17 @@ import {
   sortedRecords,
   validateCatalog,
   validateRedirects,
+  validateRemoved,
 } from "./catalog_lib.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const catalog = readJson(path.join(root, "data/catalog.json"));
 const redirects = readJson(path.join(root, "data/redirects.json"));
+const removed = readJson(path.join(root, "data/removed.json"));
 const errors = [
   ...validateCatalog(catalog),
   ...validateRedirects(redirects, catalog),
+  ...validateRemoved(removed, catalog, redirects),
 ];
 const records = sortedRecords(catalog);
 const byId = new Map(records.map((record) => [record.id, record]));

--- a/tools/catalog/catalog_lib.mjs
+++ b/tools/catalog/catalog_lib.mjs
@@ -107,6 +107,30 @@ export function validateRedirects(payload, catalog) {
   return errors;
 }
 
+// Tombstones are the "no successor" half of URL stability: redirects.json covers
+// IDs that were superseded, removed.json covers IDs that were withdrawn. An ID
+// belongs to exactly one of the two, and never to a live catalog record.
+export function validateRemoved(payload, catalog, redirects) {
+  const errors = [];
+  if (payload.schema_version !== 1) errors.push("removed.schema_version must be 1");
+  const currentIds = new Set(catalog.videos.map((record) => record.id));
+  const redirectFroms = new Set((redirects?.redirects ?? []).map((item) => item.from));
+  const seen = new Set();
+  for (const [index, entry] of (payload.removed ?? []).entries()) {
+    const at = `removed[${index}]`;
+    if (!ID_PATTERN.test(entry.id ?? "")) errors.push(`${at}.id is not canonical`);
+    if (seen.has(entry.id)) errors.push(`${at}.id duplicates ${entry.id}`);
+    seen.add(entry.id);
+    if (currentIds.has(entry.id)) errors.push(`${at}.id is still a live catalog record`);
+    if (redirectFroms.has(entry.id)) errors.push(`${at}.id is also a redirect source`);
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(entry.removed_at ?? "")) {
+      errors.push(`${at}.removed_at must be YYYY-MM-DD`);
+    }
+    if (!entry.reason?.trim()) errors.push(`${at}.reason is required`);
+  }
+  return errors;
+}
+
 export function readSceneManifests(root) {
   const sceneRoot = path.join(root, "scene-manifests");
   const byVideo = new Map();

--- a/tools/catalog/dataset.mjs
+++ b/tools/catalog/dataset.mjs
@@ -10,6 +10,7 @@ import {
   readJson,
   validateCatalog,
   validateRedirects,
+  validateRemoved,
   writeJson,
 } from "./catalog_lib.mjs";
 
@@ -105,6 +106,7 @@ function loadState() {
   return {
     catalog: readJson(path.join(root, "data/catalog.json")),
     redirects: readJson(path.join(root, "data/redirects.json")),
+    removed: readJson(path.join(root, "data/removed.json")),
   };
 }
 
@@ -112,6 +114,7 @@ function validateState(state) {
   const errors = [
     ...validateCatalog(state.catalog),
     ...validateRedirects(state.redirects, state.catalog),
+    ...validateRemoved(state.removed, state.catalog, state.redirects),
   ];
   if (errors.length) throw new Error(errors.join("\n"));
 }
@@ -120,6 +123,7 @@ function saveState(state) {
   validateState(state);
   writeJson(path.join(root, "data/catalog.json"), state.catalog);
   writeJson(path.join(root, "data/redirects.json"), state.redirects);
+  writeJson(path.join(root, "data/removed.json"), state.removed);
   run("node", ["tools/catalog/generate_views.mjs"]);
   run("node", ["tools/catalog/generate_redirect_function.mjs"]);
 }
@@ -338,6 +342,55 @@ async function rename(opts) {
   console.log(`renamed ${from} to ${to}; old objects remain until post-publish cleanup`);
 }
 
+// Withdraw an ID that has no successor. Use rename for IDs that were superseded:
+// a redirect keeps the old URL working, a tombstone deliberately kills it with a
+// 410 so search engines drop it instead of re-crawling a 404 for months.
+function remove(opts) {
+  const id = required(opts, "id");
+  const reason = required(opts, "reason");
+  const state = loadState();
+  const index = state.catalog.videos.findIndex((item) => item.id === id);
+  if (index === -1) throw new Error(`unknown catalog id ${id}`);
+  if (state.removed.removed.some((item) => item.id === id)) {
+    throw new Error(`${id} is already tombstoned`);
+  }
+  if (state.redirects.redirects.some((item) => item.to === id)) {
+    throw new Error(`${id} is the target of a redirect; repoint or drop that redirect first`);
+  }
+
+  const annotation = path.join(root, "annotations", `${id}_annotations.json`);
+  const sceneDir = path.join(root, "scene-manifests", id);
+  const hasAnnotation = fs.existsSync(annotation);
+  const hasScenes = fs.existsSync(sceneDir);
+  console.log(`will remove catalog record ${id}`);
+  console.log(`  annotation:      ${hasAnnotation ? "delete" : "none"}`);
+  console.log(`  scene manifests: ${hasScenes ? "delete" : "none"}`);
+  console.log(`  tombstone:       ${id} (${reason})`);
+  if (!opts.execute) {
+    console.log("dry run only; rerun with --execute to update the catalog");
+    return;
+  }
+
+  state.catalog.videos.splice(index, 1);
+  if (hasAnnotation) fs.rmSync(annotation);
+  if (hasScenes) fs.rmSync(sceneDir, { recursive: true });
+  state.removed.removed.push({
+    id,
+    removed_at: new Date().toISOString().slice(0, 10),
+    reason,
+  });
+  state.removed.removed.sort((a, b) => a.id.localeCompare(b.id));
+  saveState(state);
+
+  // Public objects are left in place on purpose: deleting them is irreversible
+  // and the manifest is the commit point that hides the record from readers.
+  console.log(`removed ${id}; run dataset:publish, then clean up public objects by hand:`);
+  console.log(`  aws s3 rm ${bucket}/videos/${id}.mp4`);
+  console.log(`  aws s3 rm ${bucket}/thumbnails/${id}.jpg`);
+  console.log(`  aws s3 rm ${bucket}/thumbnails/${id}/ --recursive`);
+  if (hasScenes) console.log(`  aws s3 rm ${bucket}/scenes/${id}/ --recursive`);
+}
+
 function help() {
   console.log(`Usage:
   npm run dataset:add -- --video FILE --thumbnail FILE --metadata JSON [--no-upload]
@@ -347,6 +400,7 @@ function help() {
   npm run dataset:unstar-scenes -- --ids ID,ID
   npm run dataset:unpublish-scenes -- --ids ID,ID [--execute]
   npm run dataset:rename -- --from ID --to ID --reason TEXT [--review-after DATE] --execute
+  npm run dataset:remove -- --id ID --reason TEXT [--execute]
   npm run dataset:publish
   npm run dataset:verify`);
 }
@@ -359,6 +413,7 @@ else if (command === "star-scenes") await setSceneStarred(opts, true);
 else if (command === "unstar-scenes") await setSceneStarred(opts, false);
 else if (command === "unpublish-scenes") await unpublishScenes(opts);
 else if (command === "rename") await rename(opts);
+else if (command === "remove") remove(opts);
 else if (command === "publish") run("bash", ["tools/publishing/publish_web.sh", ...(opts["skip-scenes"] ? ["--skip-scenes"] : [])]);
 else if (command === "verify") {
   run("npm", ["run", "catalog:check"]);

--- a/tools/publishing/publish_web.sh
+++ b/tools/publishing/publish_web.sh
@@ -7,6 +7,8 @@
 #   scenes/<stem>/<id>/viewer/...     3D scene data (meta + point bins + frames)
 #   annotations/<name>.json           published copy of the annotations
 #   data/videos.json                  the app manifest (list + annotations + scene index)
+#   data/redirects.json               superseded IDs -> their successor (301)
+#   data/removed.json                 withdrawn IDs with no successor (410)
 #
 # Requires AWS credentials with write access to the bucket. Run from anywhere:
 #   npm run publish-web                  # full publish (thumbnails, scenes, data)
@@ -71,11 +73,13 @@ else
   echo "== 4/5 (skipped scenes) =="
 fi
 
-echo "== 5/5 upload annotations + redirects + data manifest =="
+echo "== 5/5 upload annotations + redirects + tombstones + data manifest =="
 aws s3 sync annotations/ "$BUCKET/annotations/" \
   --exclude "*" --include "*.json" \
   --content-type application/json --cache-control "public,max-age=300"
 aws s3 cp data/redirects.json "$BUCKET/data/redirects.json" \
+  --content-type application/json --cache-control "public,max-age=300"
+aws s3 cp data/removed.json "$BUCKET/data/removed.json" \
   --content-type application/json --cache-control "public,max-age=300"
 
 if [ "${FPV_DEPLOY_REDIRECTS:-0}" = "1" ]; then


### PR DESCRIPTION
Eight `/fpv/` URLs are dead in production. Root cause: `dataset:rename` records a redirect automatically, but there is no `dataset:remove` — every removal so far has been a hand-edit of the catalog, which drops the ID silently with no redirect and no tombstone. `redirects.json` has exactly one entry, from the only rename ever done through the tool.

## What this adds

Splits URL afterlife into two manifests:

| manifest | meaning | served as |
|---|---|---|
| `data/redirects.json` | superseded ID → successor | 301 |
| `data/removed.json` | withdrawn ID, no successor | 410 (new) |

- `validateRemoved` enforces that an ID is in exactly one of the two and never also a live catalog record. Wired into `npm run audit`, so CI catches it.
- `npm run dataset:remove -- --id ID --reason TEXT [--execute]` — dry-run by default; drops the catalog record, its annotation and its scene manifests, and appends the tombstone.
- `publish_web.sh` uploads `data/removed.json` alongside `redirects.json`.

## Backfill of the eight dead IDs

**6 tombstones**, all from `067ce71` "Remove excluded videos from dataset catalog" — deliberately excluded, no equivalent footage exists.

**2 redirects**, both duplicates with a confirmed canonical:

- `2026-05-17_buggy_iskandarounah_naqoura` → `2026-05-17_military_vehicle_bayyadah_iskandarounah_mmirleb_16443` (named explicitly in `3087839`)
- `2026-05-26_humvee_vehicle_in_wadi_near_dibel` → `2026-05-26_humvee_zawtar_al_sharqiyah_riverbed_mmirleb_17068` — filed under the wrong town; confirmed by the on-screen labels in the clip, which read Zawtar al-Sharqiyah

## Note on S3

`dataset:remove` deliberately does **not** delete public objects — it prints the cleanup commands instead. Deleting them is irreversible, and the manifest is already the commit point that hides a record from readers.

## Verification

`npm run audit` and `npm run redirects:test` pass. `validateRemoved` unit-checked against a live ID, a redirect source, a malformed date and an empty reason — all rejected. Dry run confirmed non-mutating.

Pairs with itamarwe/itamarwe.github.io#104, which serves the 410. Merge order does not matter: the site fails open until `removed.json` is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)